### PR TITLE
chore: add developer onboarding tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- Describe what went wrong in plain English. -->
+
+## Expected behavior
+
+<!-- What should have happened instead? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Logs / screenshots
+
+<!-- Paste error output, screenshots, or stack traces. -->
+
+## Related
+
+<!-- Any PRs or issues this relates to. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: "[FEAT] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem / Motivation
+
+<!-- What gap or pain point does this address? -->
+
+## Proposed solution
+
+<!-- What should the feature do? Describe the happy path. -->
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Alternatives considered
+
+<!-- Other approaches you thought about. Delete if N/A. -->
+
+## Rubric alignment
+
+<!-- Which rubric criterion does this support? e.g. "LO1 functional req — blind matching" -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,31 @@
+---
+name: Task
+about: Generic implementation task (feature work, refactor, chore)
+title: "[TASK] "
+labels: task
+assignees: ''
+---
+
+## Goal
+
+<!-- What needs to happen and why? One paragraph. -->
+
+## Scope
+
+**In scope:**
+-
+
+**Out of scope:**
+-
+
+## Definition of done
+
+- [ ] Implementation complete
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (if DB or HTTP involved)
+- [ ] Merged via PR with teammate review
+- [ ] Docs updated if workflow changed
+
+## Notes
+
+<!-- Design thoughts, links, references. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- 1-2 sentences: what does this PR do and why? -->
+
+## Changes
+
+<!-- Bullet list of notable changes. -->
+-
+-
+
+## Testing
+<!-- How did you verify this works? What should Dwain run? -->
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (if this PR touches DB or HTTP)
+- [ ] Manually verified the feature works end-to-end
+- [ ] `make test` passes locally
+- [ ] `dotnet build` succeeds with no new warnings.
+
+## Screenshots
+<!-- Include screenshots for any UI changes. Delete section if N/A -->
+
+## Checklist
+- [ ] Branch named `<type>/<name>-<description>` per CONTRIBUTING.md
+- [ ] Commits follow Conventional Commits (`feat:`, `fix:`, etc.)
+- [ ] No secrets, passwords, or `.env` contents commited
+- [ ] Migration added if DbContext changed (via `dotnet ef migrations add`)
+- [ ] Related docs updated (CONTRIBUTING.md, README, inline comments)
+
+## Closes
+<!-- Which issue does this close? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,196 @@
+# Contributing to Dyadic
+
+Author: Dwain
+
+This guide covers **Local Setup**, **Day-to-Day Git Branching Rules** and **PR Conventions**, read it before your first commit : )
+
+## Table of Contents
+1. [Make Commands](#make-commands)
+2. [First-time Setup](#first-time-setup)
+3. [Running the app](#running-the-app)
+4. [Git Workflow](#git-workflow)
+5. [Commit Message Conventions](#commit-message-conventions)
+6. [Pull Requests](#pull-requests)
+7. [Testing](#testing)
+8. [Project Structure](#project-structure)
+9. [Still Stuck?](#still-stuck)
+
+
+## Make Commands
+
+This lets you use commands like:
+
+```bash
+make run
+make test
+make reset-db
+
+# See This Command Below For All Commands
+make help
+```
+So you don't have to type in long commands again...
+
+- Mac/Linux - **make** is built-in
+- Windows - needs installation:
+    - via Chocolatey: ```choco install make```
+    - via winget: ```winget install GnuWin32.Make```
+
+## First-time Setup
+
+```bash
+# Git Setup
+git clone https://github.com/NSBM-SE-Projects/dyadic.git
+cd dyadic
+
+# Dev Setup
+make setup
+```
+
+This script:
+- Checks **Pre-requisites**
+- Starts **SQL Server**
+- Configures your local **Secrets**
+- Runs **Migrations** 
+
+Note: 
+- PLEASE READ THE CLI IF THERE ARE ANY ERROR PLEASE!
+
+### Mac Members (Reminder)
+
+- Open `docker-compose.yml` and switch to the `azure-sql-edge` image line (commented instruction is in the file)
+
+## Running The App
+
+```bash
+make run
+
+# To Check If DB Is Running
+docker compose ps
+```
+
+Open the URL it prints (usually `https://localhost:5001` or `http://localhost:5000`).
+
+Stop the DB container when you're done for the day:
+
+```bash
+make down
+```
+
+## Git Workflow
+
+We use **GitHub Flow**: `main` should always be deployable, all work happens on short-lived feature branches merged via Pull Request.
+
+### Branch Naming
+
+`<type>/<name>-<short-description>` in kebab-case:
+
+| Prefix | Use for |
+|---|---|
+| `feat/` | New functionality |
+| `fix/` | Bug fix |
+| `refactor/` | Restructure, no behavior change |
+| `test/` | Tests only |
+| `docs/` | Documentation |
+| `chore/` | Config, tooling, deps |
+
+Examples:
+- `feat/thamindu-student-proposal-submission`
+- `fix/dwain-blind-filter`
+- `test/ashen-matching-service-unit-tests`
+- `chore/yameesha-bump-xunit-version`
+
+### Keep Branches Short
+
+Aim to merge within 1–3 days. If the work is too big split between branches.
+
+### Keep Latest Changes From `main`
+
+```bash
+  git checkout main
+  git pull
+  git checkout feat/your-branch
+  git merge main
+  ```
+
+## Commit Message Conventions
+
+We follow **Conventional Commits** — prefix + short summary.
+
+```
+<type>: <short summary in present tense>
+
+<optional body explaining why, not what>
+```
+
+### Micro-commits Over Mega-commits
+
+Ten commits of 20 lines each is better than one commit of 200 lines. Easier to review, easier to revert.
+
+## Pull Requests
+
+### Opening a PR
+
+1. Push your branch:
+```bash
+git push -u origin feat/your-feature-name
+```
+2. Open a PR on GitHub → base: `main`, compare: your branch.
+3. Fill out the PR template (summary, changes, testing notes).
+4. Request a review from [@dwainXDL](https://github.com/dwainXDL).
+
+### PR Requirements
+
+- You need approval from [@dwainXDL](https://github.com/dwainXDL).
+- All CI checks passing (once CI is set up)
+- No unresolved review comments
+
+## Testing
+
+Run the full test suite:
+
+```bash
+make test
+```
+
+Run one project:
+
+```bash
+dotnet test tests/Dyadic.UnitTests
+```
+
+Collect coverage:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+**Target:** >60% coverage (minimum), >80% preferred. Every PR that adds logic should add tests.
+
+- **Unit Tests** → `tests/Dyadic.UnitTests` — mock dependencies with Moq, no DB, no HTTP
+- **Integration tests** → `tests/Dyadic.IntegrationTests` — hit a real (or InMemory) DB, exercise the web
+  pipeline
+
+## Project Structure
+
+```
+.
+├── docker-compose.yml          # Local SQL Server
+├── .env.example                # Copy to .env (gitignored)
+├── Dyadic.sln
+├── src/
+│   ├── Dyadic.Domain/          # Entities, enums, domain interfaces
+│   ├── Dyadic.Application/     # Services, business rules (matching logic here)
+│   ├── Dyadic.Infrastructure/  # DbContext, EF migrations, repositories
+│   └── Dyadic.Web/             # ASP.NET Core Razor Pages — UI + controllers
+└── tests/
+    ├── Dyadic.UnitTests/
+    └── Dyadic.IntegrationTests/
+  ```
+
+**Dependency Direction:** `Web → Infrastructure → Application → Domain`. Never reverse this — `Domain` depends on nothing.
+
+## Still Stuck?
+Contact [@dwainXDL](https://github.com/dwainXDL) with:
+  - The full command you ran
+  - The full error message
+  - Output of `dotnet --version` and `docker compose ps`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# Author: Dwain
+.PHONY: help setup up down run test migrate reset-db clean fresh db-check
+
+# Default target
+help:
+	@printf "\033[1;32mDyadic - AVAILABLE COMMANDS\033[0m\n"
+	@echo " make setup          FIRST-TIME LOCAL SETUP (DOCKER, SECRETS, MIGRATIONS)"
+	@echo " make up             START THE SQL SERVER CONTAINER"
+	@echo " make down           STOP THE SQL SERVER CONTAINER (KEEP DATA!)"
+	@echo " make run            RUN THE WEB APP"
+	@echo " make test           RUN ALL TESTS"
+	@echo " make migrate        APPLY PENDING EF CORE MIGRATIONS"
+	@echo " make reset-db       WIPE DATABASE AND RE-APPLY ALL MIGRATIONS (BE CAREFUL!)"
+	@echo " make clean          REMOVE BUILD ARTIFACTS (bin/, obj/)"
+	@echo " make fresh          FULL RESET: CLEAN + RESET-DB"
+
+setup:
+	chmod +x ./setup.sh
+	./setup.sh
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+run:
+	dotnet run --project src/Dyadic.Web
+
+test:
+	dotnet test
+
+migrate:
+	dotnet ef database update -p src/Dyadic.Infrastructure -s src/Dyadic.Web
+
+reset-db:
+	docker compose down -v
+	docker compose up -d
+	@echo
+	@printf "\033[1;32mWAITING FOR SQL SERVER TO READY...\033[0m\n"
+	@echo
+	@sleep 15
+	$(MAKE) migrate
+
+clean:
+	find . -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
+
+fresh: clean reset-db
+	dotnet build
+
+db-check: ## Verify SQL Server is Accepting Connections
+	@docker ps --filter "name=dyadic-sql" --filter "status=running" --quiet | grep -q . \
+			|| { printf "\033[1;31m[fail]\033[0m  CONTAINER dyadic-sql IS NOT RUNNING. TRY: make up\n"; exit 1; }
+	@SA_PASSWORD=$$(grep '^MSSQL_SA_PASSWORD=' .env | cut -d= -f2- | tr -d '\r'); \
+	if docker exec dyadic-sql //opt/mssql-tools18/bin/sqlcmd \
+		-S localhost -U sa -P "$$SA_PASSWORD" -C -Q "SELECT 1" >/dev/null 2>&1; then \
+		printf "\033[1;32m[ok]\033[0m    SQL SERVER IS READY\n"; \
+	else \
+		printf "\033[1;31m[fail]\033[0m  SQL SERVER NOT RESPONDING... CHECK: docker compose logs db\n"; \
+		exit 1; \
+	fi 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Author: Dwain
+#
+# Dyadic - One-shot Local Dev Setup.
+# Run from project root: ./setup.sh
+#
+set -euo pipefail
+
+# Helpers
+info() { printf "\033[1;34m[info]\033[0m  %s\n" "$*"; }
+ok()  { printf "\033[1;32m[ok]\033[0m    %s\n" "$*"; }
+warn()  { printf "\033[1;33m[warn]\033[0m  %s\n" "$*"; }
+fail()  { printf "\033[1;31m[fail]\033[0m  %s\n" "$*" >&2; exit 1; }
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || fail "$1 NOT FOUND. INSTALL IT FIRST: $2"
+}
+
+# Checking Prerequisites
+info "CHECKING PRE-REQUISITES..."
+need dotnet "https://dotnet.microsoft.com/download/dotnet/8.0"
+need docker "https://www.docker.com/products/docker-desktop/"
+need git "https://git-scm.com/downloads"
+
+DOTNET_VERSION=$(dotnet --version)
+[[ "$DOTNET_VERSION" == 8.* ]] || fail ".NET 8 SDK REQUIRED (FOUND $DOTNET_VERSION)"
+ok ".NET ${DOTNET_VERSION}"
+
+docker info >/dev/null 2>&1 || fail "DOCKER DAEMON NOT RUNNING. START DOCKER DESKTOP FIRST."
+ok "DOCKER DAEMON IS RUNNING"
+
+# Creating .env (if missing)
+if [[ ! -f .env ]]; then
+    info "CREATING .env FROM .env.example..."
+    cp .env.example .env
+    warn "USING DEFAULT PASSWORD FROM .env.example. EDIT .env IF YOU WANT MORE SECURITY (>=8, upper+lower+digit+symbol)."
+    ok ".env CREATED!"
+fi
+ok ".env EXISTS"
+
+# Extract Password (stripping CR in case of CRLF line endings)
+SA_PASSWORD=$(grep '^MSSQL_SA_PASSWORD=' .env | cut -d= -f2- | tr -d '\r')
+[[ -n "$SA_PASSWORD" ]] || fail "MSSQL_SA_PASSWORD IS EMPTY IN .env"
+# Validating SQL Server Password Complexity
+validate_password() {
+    local pw=$1
+
+    # Quotes In .env
+    if [[ "$pw" =~ ^[\"\'].*[\"\']$ ]]; then
+        fail "REMOVE SORROUNDING QUOTES FROM MSSQL_SA_PASSWORD IN .env"
+    fi
+
+    # Whitespace - Warning
+    if [[ "$pw" =~ ^[[:space:]] ]] || [[ "$pw" =~ [[:space:]]$ ]]; then
+        warn "PASSWORD HAS WHITESPACE - PLEASE REMOVE FROM .env"
+    fi
+
+    
+    # Length (More Than 8 Characters)
+    [[ ${#pw} -ge 8 ]] || { fail "MSSQL_SA_PASSWORD MUST BE AT LEAST 8 CHARACTERS (got ${#pw})"; }
+
+    # Password Complexity Check
+    local missing=()
+    [[ "$pw" =~ [A-Z] ]]            || missing+=("AN UPPERCASE LETTER(A-Z)")
+    [[ "$pw" =~ [a-z] ]]            || missing+=("A LOWERCASE LETTER (a-z)")
+    [[ "$pw" =~ [0-9] ]]            || missing+=("A DIGIT (0-9)")
+    [[ "$pw" =~ [^a-zA-Z0-9] ]]     || missing+=("A SYMBOL (e.g. @, !, #)")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        fail "PASSWORD IS MISSING: $(IFS=', ';echo "${missing[*]}")"
+    fi
+    
+    # SQL Server Rejects Passwords Containing The Login Name
+    [[ "$pw" != *sa* ]] && [[ "$pw" != *SA* ]] || warn "PASSWORD CONTAINS 'sa' - SQL SERVER COULD REJECT IT"
+}
+
+validate_password "$SA_PASSWORD"
+ok "PASSWORD MEETS COMPLEXITY REQUIREMENTS"
+
+# Starting SQL Server Container
+info "STARTING SQL SERVER CONTAINER..."
+docker compose up -d
+
+info "WAITING FOR SQL SERVER TO ACCEPT CONNECTIONS..."
+for i in {1..30}; do
+    if docker exec dyadic-sql //opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P "$SA_PASSWORD" -C -Q "SELECT 1" >/dev/null 2>&1; then
+        ok "SQL SERVER READY"
+        break
+    fi
+    [[ $i -eq 30 ]] && fail "SQL SERVER NOT READY AFTER 60s. CHECK: docker compose logs db"
+    sleep 2
+done
+
+# Configure User Secrets
+info "CONFIGURING USER SECRETS..."
+CONN_STR="Server=localhost,1433;Database=Dyadic;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True;"
+(
+    cd src/Dyadic.Web
+    dotnet user-secrets set "ConnectionStrings:DefaultConnection" "$CONN_STR" >/dev/null
+)
+ok "USER SECRETS SET FOR Dyadic.Web"
+
+# Restore Local Dotnet Tools
+info "RESTORING DOTNET TOOLS (dotnet-ef etc.)..."
+dotnet tool restore >/dev/null
+ok "TOOLS RESTORED"
+
+# Apply Migrations
+info "APPLYING EF CORE MIGRATIONS..."
+dotnet ef database update -p src/Dyadic.Infrastructure -s src/Dyadic.Web
+ok "DATABASE MIGRATED"
+
+# Build
+info "BUILDING SOLUTION..."
+dotnet build --nologo -v minimal
+ok "BUILD SUCCEEDED!"
+
+printf "\n\033[1;32mSETUP COMPLETE.\033[0m  RUN THE APP WITH:\n  dotnet run --project src/Dyadic.Web\n\n"


### PR DESCRIPTION
## Summary
Add developer onboarding tooling:  
- `setup.sh` — one-shot script: checks prereqs, configures .env, starts Docker, sets User Secrets, runs migrations
- `Makefile` — common commands (`make setup`, `make up`, `make test`, `make db-check`, etc.)
- `CONTRIBUTING.md` — team workflow, branch naming, commit conventions, PR process

## Changes
- New: `setup.sh`, `Makefile`, `CONTRIBUTING.md`

## Testing
- [x] `make setup` from clean state — creates .env, starts container, migrates DB
- [x] `make db-check` — verifies SQL Server connection
- [x] `make reset-db` — wipes and re-migrates
- [x] `make help` — prints command list

## Notes
After merge, teammates should re-run `make setup` to align with the new flow.