### PR TITLE
feat(domain): add core entities and initial schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 memory/
 references/
 CLAUDE.md
+.claude
 
 # User-specific files
 *.rsuser

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo " make reset-db       WIPE DATABASE AND RE-APPLY ALL MIGRATIONS (BE CAREFUL!)"
 	@echo " make clean          REMOVE BUILD ARTIFACTS (bin/, obj/)"
 	@echo " make fresh          FULL RESET: CLEAN + RESET-DB"
+	@echo " make db-check       CHECK CONDITION OF DOCKER DATABASE"
 
 setup:
 	chmod +x ./setup.sh

--- a/src/Dyadic.Domain/Class1.cs
+++ b/src/Dyadic.Domain/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Dyadic.Domain;
-
-public class Class1
-{
-
-}

--- a/src/Dyadic.Domain/Entities/Proposal.cs
+++ b/src/Dyadic.Domain/Entities/Proposal.cs
@@ -1,0 +1,19 @@
+using Dyadic.Domain.Enums;
+
+namespace Dyadic.Domain.Entities;
+
+public class Proposal {
+    public Guid Id { get; set; }
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+
+    public Guid StudentId { get; set; }
+    public StudentProfile Student { get; set; } = null!;
+
+    public Guid? SupervisorId { get; set; }
+    public SupervisorProfile? Supervisor { get; set; }
+
+    public ProposalStatus Status { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+

--- a/src/Dyadic.Domain/Entities/StudentProfile.cs
+++ b/src/Dyadic.Domain/Entities/StudentProfile.cs
@@ -1,0 +1,12 @@
+namespace Dyadic.Domain.Entities;
+
+public class StudentProfile {
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+
+    public required string IndexNumber { get; set; }
+    public required string Batch { get; set; }
+
+    public Proposal? Proposal { get; set; }
+}

--- a/src/Dyadic.Domain/Entities/SupervisorProfile.cs
+++ b/src/Dyadic.Domain/Entities/SupervisorProfile.cs
@@ -1,0 +1,12 @@
+namespace Dyadic.Domain.Entities;
+
+public class SupervisorProfile {
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+
+    public required string Department { get; set; }
+    public int MaxStudents { get; set; }
+
+    public ICollection<Proposal> AcceptedProposal { get; set; } = new List<Proposal>();
+}

--- a/src/Dyadic.Domain/Entities/SupervisorProfile.cs
+++ b/src/Dyadic.Domain/Entities/SupervisorProfile.cs
@@ -8,5 +8,5 @@ public class SupervisorProfile {
     public required string Department { get; set; }
     public int MaxStudents { get; set; }
 
-    public ICollection<Proposal> AcceptedProposal { get; set; } = new List<Proposal>();
+    public ICollection<Proposal> AcceptedProposals { get; set; } = new List<Proposal>();
 }

--- a/src/Dyadic.Domain/Entities/User.cs
+++ b/src/Dyadic.Domain/Entities/User.cs
@@ -1,0 +1,14 @@
+using Dyadic.Domain.Enums;
+
+namespace Dyadic.Domain.Entities;
+
+public class User {
+    public Guid Id { get; set; }
+    public required string Email { get; set; }
+    public required string FullName { get; set; }
+    public UserRole Role { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public StudentProfile? StudentProfile { get; set; }
+    public SupervisorProfile? SupervisorProfile { get; set; }
+}

--- a/src/Dyadic.Domain/Enums/ProposalStatus.cs
+++ b/src/Dyadic.Domain/Enums/ProposalStatus.cs
@@ -1,0 +1,9 @@
+namespace Dyadic.Domain.Enums;
+
+public enum ProposalStatus {
+    Draft,
+    Submitted,
+    Accepted,
+    Rejected,
+    Finalized
+}

--- a/src/Dyadic.Domain/Enums/UserRole.cs
+++ b/src/Dyadic.Domain/Enums/UserRole.cs
@@ -1,0 +1,8 @@
+namespace Dyadic.Domain.Enums;
+
+public enum UserRole
+{
+    Student,
+    Supervisor,
+    Admin
+}

--- a/src/Dyadic.Infrastructure/ApplicationDbContext.cs
+++ b/src/Dyadic.Infrastructure/ApplicationDbContext.cs
@@ -1,13 +1,54 @@
+using Dyadic.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Dyadic.Infrastructure;
 
-public class ApplicationDbContext: DbContext {
+public class ApplicationDbContext : DbContext {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-        :base(options)
-    {
-    }
+        : base(options) { }
 
-    // DbSet<T> properties go here as entities are added
-    // Example: public DbSet<Proposal> Proposals => Set<Proposal>();
+    public DbSet<User> Users => Set<User>();
+    public DbSet<StudentProfile> StudentProfiles => Set<StudentProfile>();
+    public DbSet<SupervisorProfile> SupervisorProfiles => Set<SupervisorProfile>();
+    public DbSet<Proposal> Proposals => Set<Proposal>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) {
+        // User <> StudentProfile (1:1)
+        modelBuilder.Entity<User>()
+        .HasOne(u => u.StudentProfile)
+        .WithOne(sp => sp.User)
+        .HasForeignKey<StudentProfile>(sp => sp.UserId);
+
+        // User <> SupervisorProfile (1:1)
+        modelBuilder.Entity<User>()
+            .HasOne(u => u.SupervisorProfile)
+            .WithOne(sp => sp.User)
+            .HasForeignKey<SupervisorProfile>(sp => sp.UserId);
+
+        // StudentProfile <> Proposal (1:1 - one proposal per student)
+        modelBuilder.Entity<StudentProfile>()
+            .HasOne(sp => sp.Proposal)
+            .WithOne(p => p.Student)
+            .HasForeignKey<Proposal>(p => p.StudentId);
+
+        // SupervisorProfile <> Proposals (1:many - supervisor accepts multiple)
+        modelBuilder.Entity<SupervisorProfile>()
+            .HasMany(sp => sp.AcceptedProposals)
+            .WithOne(p => p.Supervisor)
+            .HasForeignKey(p => p.SupervisorId);
+
+        // Unique Email
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Email)
+            .IsUnique();
+
+        // Store enums as string
+        modelBuilder.Entity<User>()
+            .Property(u => u.Role)
+            .HasConversion<string>();
+
+        modelBuilder.Entity<Proposal>()
+            .Property(p => p.Status)
+            .HasConversion<string>();
+    }
 }

--- a/src/Dyadic.Infrastructure/Migrations/20260416170158_AddCoreEntities.Designer.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260416170158_AddCoreEntities.Designer.cs
@@ -4,6 +4,7 @@ using Dyadic.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dyadic.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416170158_AddCoreEntities")]
+    partial class AddCoreEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dyadic.Infrastructure/Migrations/20260416170158_AddCoreEntities.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260416170158_AddCoreEntities.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dyadic.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoreEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    FullName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Role = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StudentProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IndexNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Batch = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StudentProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StudentProfiles_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SupervisorProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Department = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    MaxStudents = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SupervisorProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SupervisorProfiles_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Proposals",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    StudentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SupervisorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Proposals", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Proposals_StudentProfiles_StudentId",
+                        column: x => x.StudentId,
+                        principalTable: "StudentProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Proposals_SupervisorProfiles_SupervisorId",
+                        column: x => x.SupervisorId,
+                        principalTable: "SupervisorProfiles",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Proposals_StudentId",
+                table: "Proposals",
+                column: "StudentId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Proposals_SupervisorId",
+                table: "Proposals",
+                column: "SupervisorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StudentProfiles_UserId",
+                table: "StudentProfiles",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SupervisorProfiles_UserId",
+                table: "SupervisorProfiles",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Proposals");
+
+            migrationBuilder.DropTable(
+                name: "StudentProfiles");
+
+            migrationBuilder.DropTable(
+                name: "SupervisorProfiles");
+
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add User + StudentProfile + SupervisorProfile (1:1) and Proposal entities
- Wire relationships and enum-as-string conversions in ApplicationDbContext
- Generate AddCoreEntities migration

## Changes
- Add `Dyadic.Domain/Entities/` with User, StudentProfile, SupervisorProfile, Proposal
- Add `Dyadic.Domain/Enums/` with UserRole and ProposalStatus
- Configure 1:1 (User<>Profiles, Student<>Proposal) and 1:many (Supervisor=>Proposals) relationships
- Add unique index on User.Email
- Store UserRole and ProposalStatus as strings for SQL readability
- Remove default Class1.cs placeholder

## Testing
- [ ] Unit tests added/updated *(deferred — entities are POCOs; tests come with the service layer)*
- [ ] Integration tests added/updated *(deferred — DbContext tests planned for separate PR)*
- [x] Manually verified the feature works end-to-end *(tables visible in dyadic-sql)*
- [x] `make test` passes locally *(no tests exist yet)*
- [x] `dotnet build` succeeds with no new warnings

## Screenshots
N/A — backend-only change.

## Checklist
- [x] Branch named `<type>/<name>-<description>` per CONTRIBUTING.md
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] No secrets, passwords, or .env contents committed
- [x] Migration added if DbContext changed (via `dotnet ef migrations add`)
- [ ] Related docs updated *(no doc changes needed — internal scaffolding)*

Closes #21 