### PR TITLE
feat(web): add status code pages middleware and 404 handling

### DIFF
--- a/src/Dyadic.Web/Pages/Error.cshtml
+++ b/src/Dyadic.Web/Pages/Error.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="text-center py-5">
-    @if (Model.StatusCode == 404) {
+    @if (Model.ErrorStatusCode == 404) {
         <h1 class="display-1 text-warning">404</h1>
         <h2 class="fw-bold">Page not found</h2>
         <p class="text-muted">The page you're looking for doesn't exist.</p>

--- a/src/Dyadic.Web/Pages/Error.cshtml
+++ b/src/Dyadic.Web/Pages/Error.cshtml
@@ -5,16 +5,23 @@
 }
 
 <div class="text-center py-5">
-    <h1 class="display-1 text-danger">&#9888;</h1>
-    <h2 class="fw-bold">Something went wrong</h2>
-    <p class="text-muted">An error occurred while processing your request.</p>
-
-    @if (Model.ShowRequestId)
-    {
+    @if (Model.StatusCode == 404) {
+        <h1 class="display-1 text-warning">404</h1>
+        <h2 class="fw-bold">Page not found</h2>
+        <p class="text-muted">The page you're looking for doesn't exist.</p>
+    }
+    else {
+        <h1 class="display-1 text-danger">&#9888;</h1>
+        <h2 class="fw-bold">Something went wrong</h2>
+        <p class="text-muted">An error occurred while processing your request.</p>
+    
+        @if (Model.ShowRequestId)
+        {
         <p class="text-muted small">
             <strong>Request ID:</strong> <code>@Model.RequestId</code>
         </p>
+        }
     }
-
+    
     <a asp-page="/Index" class="btn btn-success mt-3">Go Home</a>
 </div>

--- a/src/Dyadic.Web/Pages/Error.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Error.cshtml.cs
@@ -12,6 +12,8 @@ public class ErrorModel : PageModel
 
     public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
+    public int StatusCode { get; set; }
+
     private readonly ILogger<ErrorModel> _logger;
 
     public ErrorModel(ILogger<ErrorModel> logger)
@@ -19,9 +21,10 @@ public class ErrorModel : PageModel
         _logger = logger;
     }
 
-    public void OnGet()
+    public void OnGet(int? statusCode)
     {
         RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        StatusCode = statusCode ?? HttpContext.Response.StatusCode;
     }
 }
 

--- a/src/Dyadic.Web/Pages/Error.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Error.cshtml.cs
@@ -12,7 +12,7 @@ public class ErrorModel : PageModel
 
     public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-    public int StatusCode { get; set; }
+    public int ErrorStatusCode { get; set; }
 
     private readonly ILogger<ErrorModel> _logger;
 
@@ -24,7 +24,7 @@ public class ErrorModel : PageModel
     public void OnGet(int? statusCode)
     {
         RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-        StatusCode = statusCode ?? HttpContext.Response.StatusCode;
+        ErrorStatusCode = statusCode ?? HttpContext.Response.StatusCode;
     }
 }
 

--- a/src/Dyadic.Web/Program.cs
+++ b/src/Dyadic.Web/Program.cs
@@ -47,6 +47,9 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthentication();
+
+app.UseStatusCodePagesWithReExecute("/Error", "?statusCode={0}");
+
 app.UseAuthorization();
 
 app.MapRazorPages();


### PR DESCRIPTION
## Summary
Add `UseStatusCodePagesWithReExecute` middleware and update the Error page to show a friendly 404 for missing pages.

## Changes
- Add `UseStatusCodePagesWithReExecute("/Error", "?statusCode={0}")` in `Program.cs`
- Update `Error.cshtml` with distinct 404 vs generic error display
- Update `ErrorModel` to accept and expose `statusCode` parameter

## Testing
- [x] `dotnet build` succeeds
- [x] Navigating to `/nonexistent` shows styled 404 page
- [x] Other errors still show generic error page

## Screenshot
<img width="2521" height="1335" alt="vivaldi_0knR2ZCW0O" src="https://github.com/user-attachments/assets/7ebf258f-23cb-44ad-bccd-82b98b135a50" />


## Checklist
- [x] Branch named per CONTRIBUTING.md
- [x] Commits follow Conventional Commits
- [x] No secrets committed

## Related
Builds on Issue #24 (shared layout). Improves error handling for all future pages.