### PR TITLE
feat(web): add student proposal edit and withdraw

### DIFF
--- a/src/Dyadic.Application/Services/IProposalService.cs
+++ b/src/Dyadic.Application/Services/IProposalService.cs
@@ -9,4 +9,5 @@ public interface IProposalService
     Task<Proposal> UpdateDraftAsync(Guid proposalId, string title, string description);
     Task<Proposal> SubmitAsync(Guid proposalId);
     Task<Proposal?> GetByStudentIdAsync(Guid studentProfileId);
+    Task<Proposal> WithdrawAsync(Guid proposalId, Guid studentProfileId);
 }

--- a/src/Dyadic.Infrastructure/Services/ProposalService.cs
+++ b/src/Dyadic.Infrastructure/Services/ProposalService.cs
@@ -52,6 +52,9 @@ public class ProposalService : IProposalService
         var proposal = await _db.Proposals.FindAsync(proposalId)
             ?? throw new InvalidOperationException("Proposal not found.");
 
+        if (proposal.Status != ProposalStatus.Draft)
+            throw new InvalidOperationException("Only draft proposals can be edited.");
+
         proposal.Title = title;
         proposal.Description = description;
         await _db.SaveChangesAsync();
@@ -75,5 +78,21 @@ public class ProposalService : IProposalService
     {
         return await _db.Proposals
             .FirstOrDefaultAsync(p => p.StudentId == studentProfileId);
+    }
+
+    public async Task<Proposal> WithdrawAsync(Guid proposalId, Guid studentProfileId)
+    {
+        var proposal = await _db.Proposals.FindAsync(proposalId)
+            ?? throw new InvalidOperationException("Proposal not found.");
+
+        if (proposal.StudentId != studentProfileId)
+            throw new InvalidOperationException("You do not own this proposal.");
+
+        if (proposal.Status != ProposalStatus.Submitted)
+            throw new InvalidOperationException("Only submitted proposals can be withdrawn.");
+
+        proposal.Status = ProposalStatus.Draft;
+        await _db.SaveChangesAsync();
+        return proposal;
     }
 }

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
@@ -39,9 +39,28 @@
                 <dd class="col-sm-9">@Model.Proposal.CreatedAt.ToLocalTime().ToString("dd MMM yyyy")</dd>
             </dl>
 
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
             @if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Draft)
             {
-                <a asp-page="/Student/SubmitProposal" class="btn btn-outline-secondary">Edit Draft</a>
+                <div class="d-flex gap-2">
+                    <a asp-page="/Student/SubmitProposal" class="btn btn-outline-secondary">Edit Draft</a>
+                    <a asp-page="/Student/SubmitProposal" class="btn btn-success">Submit Proposal</a>
+                </div>
+            }
+            else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Submitted)
+            {
+                <form method="post">
+                    <button type="submit" asp-page-handler="Withdraw"
+                            class="btn btn-outline-danger"
+                            onclick="return confirm('Are you sure you want to withdraw your proposal? It will return to Draft status.')">
+                        Withdraw Proposal
+                    </button>
+                </form>
+            }
+            else
+            {
+                <p class="text-muted fst-italic">This proposal is locked and cannot be edited.</p>
             }
         }
     </div>

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
@@ -37,4 +37,27 @@ public class MyProposalModel : PageModel
 
         return Page();
     }
+
+    public async Task<IActionResult> OnPostWithdrawAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Forbid();
+
+        var profile = await _proposalService.GetOrCreateStudentProfileAsync(user.Id);
+        var proposal = await _proposalService.GetByStudentIdAsync(profile.Id);
+        if (proposal == null) return RedirectToPage("/Student/SubmitProposal");
+
+        try
+        {
+            await _proposalService.WithdrawAsync(proposal.Id, profile.Id);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            Proposal = proposal;
+            return Page();
+        }
+
+        return RedirectToPage("/Student/MyProposal");
+    }
 }

--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml
@@ -26,13 +26,19 @@
                 <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
                 <div class="mb-3">
-                    <label asp-for="Input.Title" class="form-label fw-semibold"></label>
-                    <input asp-for="Input.Title" class="form-control form-control-lg" maxlength="200" />
+                    <div class="d-flex justify-content-between">
+                        <label asp-for="Input.Title" class="form-label fw-semibold"></label>
+                        <small class="text-muted"><span id="titleCount">200</span> characters remaining</small>
+                    </div>
+                    <input asp-for="Input.Title" class="form-control form-control-lg" maxlength="200" id="titleInput" />
                     <span asp-validation-for="Input.Title" class="text-danger small"></span>
                 </div>
                 <div class="mb-4">
-                    <label asp-for="Input.Description" class="form-label fw-semibold"></label>
-                    <textarea asp-for="Input.Description" class="form-control" rows="8" maxlength="2000"></textarea>
+                    <div class="d-flex justify-content-between">
+                        <label asp-for="Input.Description" class="form-label fw-semibold"></label>
+                        <small class="text-muted"><span id="descCount">2000</span> characters remaining</small>
+                    </div>
+                    <textarea asp-for="Input.Description" class="form-control" rows="8" maxlength="2000" id="descInput"></textarea>
                     <span asp-validation-for="Input.Description" class="text-danger small"></span>
                 </div>
 
@@ -47,4 +53,18 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        function updateCount(inputId, countId, max) {
+            const input = document.getElementById(inputId);
+            const count = document.getElementById(countId);
+            if (input && count) {
+                count.textContent = max - input.value.length;
+                input.addEventListener('input', () => {
+                    count.textContent = max - input.value.length;
+                });
+            }
+        }
+        updateCount('titleInput', 'titleCount', 200);
+        updateCount('descInput', 'descCount', 2000);
+    </script>
 }

--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
@@ -25,7 +25,7 @@ public class SubmitProposalModel : PageModel
     public InputModel Input { get; set; } = new();
 
     public bool IsSubmitted { get; set; }
-
+    public bool IsLocked { get; set; }
     public class InputModel
     {
         [Required, MaxLength(200)]
@@ -47,7 +47,14 @@ public class SubmitProposalModel : PageModel
         {
             Input.Title = proposal.Title;
             Input.Description = proposal.Description;
-            IsSubmitted = proposal.Status != ProposalStatus.Draft;
+            IsSubmitted = proposal.Status == ProposalStatus.Submitted;
+            IsLocked = proposal.Status == ProposalStatus.Accepted || proposal.Status == ProposalStatus.Finalized;
+
+            if (IsLocked)
+            {
+                Response.Redirect("/Student/MyProposal");
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
  - Students can withdraw a submitted proposal (status → Draft) with a confirmation dialog
  - Withdrawn proposals can be edited and resubmitted
  - Accepted/Finalized proposals are read-only — no action buttons shown
  - Direct navigation to SubmitProposal redirects to MyProposal if proposal is locked
  - Character counters added to Title (200) and Description (2000) fields
  - Guarded UpdateDraftAsync against editing non-Draft proposals

  ## Changes
  - \`Application/Services/IProposalService.cs\` — added \`WithdrawAsync\`
  - \`Infrastructure/Services/ProposalService.cs\` — implemented \`WithdrawAsync\`, guarded \`UpdateDraftAsync\`
  - \`Web/Pages/Student/MyProposal.cshtml\` — status-aware action buttons with withdraw confirmation
  - \`Web/Pages/Student/MyProposal.cshtml.cs\` — added \`OnPostWithdrawAsync\`
  - \`Web/Pages/Student/SubmitProposal.cshtml\` — character counters
  - \`Web/Pages/Student/SubmitProposal.cshtml.cs\` — redirect locked proposals to MyProposal

  ## Testing
  - [x] Manually verified all flows end-to-end
  - [x] \`dotnet build\` succeeds with no new warnings
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] \`make test\` passes locally

## Screenshots
<img width="2520" height="1329" alt="vivaldi_dJcgxxB1Sb" src="https://github.com/user-attachments/assets/d1cdf2a2-66bc-42c0-ba38-98046e493d6e" />
<img width="2516" height="1335" alt="vivaldi_GAOZB9Ug1j" src="https://github.com/user-attachments/assets/3466d48a-2477-409a-8806-a0edf2beb805" />

  ## Checklist
  - [x] Branch named per CONTRIBUTING.md
  - [x] Commits follow Conventional Commits
  - [x] No secrets, passwords, or \`.env\` contents committed

  ## Closes
  Closes #37