### PR TITLE
feat(student): add two-way match confirmation and identity reveal

### DIFF
--- a/src/Dyadic.Application/Services/IProposalService.cs
+++ b/src/Dyadic.Application/Services/IProposalService.cs
@@ -12,4 +12,6 @@ public interface IProposalService
     Task<List<Proposal>> GetSubmittedProposalsAsync();
     Task<Proposal> AcceptProposalAsync(Guid proposalId, Guid supervisorProfileId);
     Task<List<Proposal>> GetAcceptedBySupervisorAsync(Guid supervisorProfileId);
+    Task<Proposal> ConfirmMatchAsync(Guid proposalId, Guid studentProfileId);
+    Task<Proposal> RejectMatchAsync(Guid proposalId, Guid studentProfileId);
 }

--- a/src/Dyadic.Infrastructure/Services/ProposalService.cs
+++ b/src/Dyadic.Infrastructure/Services/ProposalService.cs
@@ -74,6 +74,7 @@ public class ProposalService : IProposalService
     public async Task<Proposal?> GetByStudentIdAsync(Guid studentProfileId)
     {
         return await _db.Proposals
+            .Include(p => p.Supervisor).ThenInclude(sp => sp!.User)
             .FirstOrDefaultAsync(p => p.StudentId == studentProfileId);
     }
 
@@ -110,8 +111,43 @@ public class ProposalService : IProposalService
     public async Task<List<Proposal>> GetAcceptedBySupervisorAsync(Guid supervisorProfileId)
     {
         return await _db.Proposals
-            .Where(p => p.SupervisorId == supervisorProfileId && p.Status == ProposalStatus.Accepted)
+            .Include(p => p.Student).ThenInclude(sp => sp.User)
+            .Where(p => p.SupervisorId == supervisorProfileId &&
+                        (p.Status == ProposalStatus.Accepted || p.Status == ProposalStatus.Finalized))
             .OrderByDescending(p => p.CreatedAt)
             .ToListAsync();
+    }
+
+    public async Task<Proposal> ConfirmMatchAsync(Guid proposalId, Guid studentProfileId)
+    {
+        var proposal = await _db.Proposals.FindAsync(proposalId)
+            ?? throw new InvalidOperationException("Proposal not found.");
+
+        if (proposal.StudentId != studentProfileId)
+            throw new InvalidOperationException("You do not own this proposal.");
+
+        if (proposal.Status != ProposalStatus.Accepted)
+            throw new InvalidOperationException("Only accepted proposals can be confirmed.");
+
+        proposal.Status = ProposalStatus.Finalized;
+        await _db.SaveChangesAsync();
+        return proposal;
+    }
+
+    public async Task<Proposal> RejectMatchAsync(Guid proposalId, Guid studentProfileId)
+    {
+        var proposal = await _db.Proposals.FindAsync(proposalId)
+            ?? throw new InvalidOperationException("Proposal not found.");
+
+        if (proposal.StudentId != studentProfileId)
+            throw new InvalidOperationException("You do not own this proposal.");
+
+        if (proposal.Status != ProposalStatus.Accepted)
+            throw new InvalidOperationException("Only accepted proposals can be rejected.");
+
+        proposal.Status = ProposalStatus.Submitted;
+        proposal.SupervisorId = null;
+        await _db.SaveChangesAsync();
+        return proposal;
     }
 }

--- a/src/Dyadic.Infrastructure/Services/ProposalService.cs
+++ b/src/Dyadic.Infrastructure/Services/ProposalService.cs
@@ -76,9 +76,17 @@ public class ProposalService : IProposalService
 
     public async Task<Proposal?> GetByStudentIdAsync(Guid studentProfileId)
     {
-        return await _db.Proposals
-            .Include(p => p.Supervisor).ThenInclude(sp => sp!.User)
+        var proposal = await _db.Proposals
             .FirstOrDefaultAsync(p => p.StudentId == studentProfileId);
+
+        if (proposal?.Status == ProposalStatus.Finalized)
+            await _db.Entry(proposal)
+                .Reference(p => p.Supervisor)
+                .Query()
+                .Include(sp => sp.User)
+                .LoadAsync();
+
+        return proposal;
     }
 
     public async Task<Proposal> WithdrawAsync(Guid proposalId, Guid studentProfileId)
@@ -129,12 +137,20 @@ public class ProposalService : IProposalService
 
     public async Task<List<Proposal>> GetAcceptedBySupervisorAsync(Guid supervisorProfileId)
     {
-        return await _db.Proposals
-            .Include(p => p.Student).ThenInclude(sp => sp.User)
+        var proposals = await _db.Proposals
             .Where(p => p.SupervisorId == supervisorProfileId &&
                         (p.Status == ProposalStatus.Accepted || p.Status == ProposalStatus.Finalized))
             .OrderByDescending(p => p.CreatedAt)
             .ToListAsync();
+
+        foreach (var proposal in proposals.Where(p => p.Status == ProposalStatus.Finalized))
+            await _db.Entry(proposal)
+                .Reference(p => p.Student)
+                .Query()
+                .Include(sp => sp.User)
+                .LoadAsync();
+
+        return proposals;
     }
 
     public async Task<Proposal> ConfirmMatchAsync(Guid proposalId, Guid studentProfileId)

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
@@ -43,6 +43,41 @@
             {
                 <a asp-page="/Student/SubmitProposal" class="btn btn-outline-secondary">Edit Draft</a>
             }
+            else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Accepted)
+            {
+                <div class="alert alert-info mt-3">
+                    A supervisor has expressed interest in your proposal.
+                </div>
+                <form method="post" class="d-inline me-2">
+                    <input type="hidden" name="proposalId" value="@Model.Proposal.Id" />
+                    <button type="submit" asp-page-handler="Confirm" class="btn btn-success"
+                            onclick="return confirm('Confirm this match? This will finalize your proposal.')">
+                        Confirm Match
+                    </button>
+                </form>
+                <form method="post" class="d-inline">
+                    <input type="hidden" name="proposalId" value="@Model.Proposal.Id" />
+                    <button type="submit" asp-page-handler="Reject" class="btn btn-outline-danger"
+                            onclick="return confirm('Decline this match? Your proposal will return to the pool.')">
+                        Decline Match
+                    </button>
+                </form>
+            }
+            else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Finalized)
+            {
+                <div class="alert alert-success mt-3">
+                    <strong>Congratulations! Your match has been finalized.</strong>
+                </div>
+                <h5 class="mt-3">Your Supervisor</h5>
+                <dl class="row">
+                    <dt class="col-sm-3">Name</dt>
+                    <dd class="col-sm-9">@Model.Proposal.Supervisor!.User.FullName</dd>
+                    <dt class="col-sm-3">Email</dt>
+                    <dd class="col-sm-9">@Model.Proposal.Supervisor.User.Email</dd>
+                    <dt class="col-sm-3">Department</dt>
+                    <dd class="col-sm-9">@Model.Proposal.Supervisor.Department</dd>
+                </dl>
+            }
         }
     </div>
 </div>

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
@@ -91,6 +91,11 @@
                     <dd class="col-sm-9">@Model.Proposal.Supervisor.User.Email</dd>
                     <dt class="col-sm-3">Department</dt>
                     <dd class="col-sm-9">@Model.Proposal.Supervisor.Department</dd>
+                    @if (!string.IsNullOrWhiteSpace(Model.Proposal.Supervisor.ResearchAreas))
+                    {
+                        <dt class="col-sm-3">Research Areas</dt>
+                        <dd class="col-sm-9">@Model.Proposal.Supervisor.ResearchAreas</dd>
+                    }
                 </dl>
             }
             else

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
@@ -37,4 +37,24 @@ public class MyProposalModel : PageModel
 
         return Page();
     }
+
+    public async Task<IActionResult> OnPostConfirmAsync(Guid proposalId)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Forbid();
+
+        var profile = await _proposalService.GetOrCreateStudentProfileAsync(user.Id);
+        await _proposalService.ConfirmMatchAsync(proposalId, profile.Id);
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostRejectAsync(Guid proposalId)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return Forbid();
+
+        var profile = await _proposalService.GetOrCreateStudentProfileAsync(user.Id);
+        await _proposalService.RejectMatchAsync(proposalId, profile.Id);
+        return RedirectToPage();
+    }
 }

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml.cs
@@ -67,7 +67,18 @@ public class MyProposalModel : PageModel
         if (user == null) return Forbid();
 
         var profile = await _proposalService.GetOrCreateStudentProfileAsync(user.Id);
-        await _proposalService.ConfirmMatchAsync(proposalId, profile.Id);
+
+        try
+        {
+            await _proposalService.ConfirmMatchAsync(proposalId, profile.Id);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            Proposal = await _proposalService.GetByStudentIdAsync(profile.Id);
+            return Page();
+        }
+
         return RedirectToPage();
     }
 
@@ -77,7 +88,18 @@ public class MyProposalModel : PageModel
         if (user == null) return Forbid();
 
         var profile = await _proposalService.GetOrCreateStudentProfileAsync(user.Id);
-        await _proposalService.RejectMatchAsync(proposalId, profile.Id);
+
+        try
+        {
+            await _proposalService.RejectMatchAsync(proposalId, profile.Id);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            Proposal = await _proposalService.GetByStudentIdAsync(profile.Id);
+            return Page();
+        }
+
         return RedirectToPage();
     }
 }

--- a/src/Dyadic.Web/Pages/Supervisor/AcceptedProposals.cshtml
+++ b/src/Dyadic.Web/Pages/Supervisor/AcceptedProposals.cshtml
@@ -24,6 +24,7 @@
                         <th>Description</th>
                         <th>Date</th>
                         <th>Status</th>
+                        <th>Student</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -43,6 +44,18 @@
                                     };
                                 }
                                 <span class="badge @badgeClass">@badgeText</span>
+                            </td>
+                            <td>
+                                @if (proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Finalized)
+                                {
+                                    <div>@proposal.Student.User.FullName</div>
+                                    <div class="text-muted small">@proposal.Student.User.Email</div>
+                                    <div class="text-muted small">@proposal.Student.IndexNumber — @proposal.Student.Batch</div>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">Waiting for student confirmation</span>
+                                }
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
## Summary

Adds two-way match confirmation so students can accept or reject supervisor interest. Once confirmed, identity is revealed on both sides; once rejected, the proposal returns to the blind pool.

- Add `ConfirmMatchAsync` and `RejectMatchAsync` to `IProposalService`
- Student confirm: `Accepted → Finalized`, reveals supervisor name / email / department / research areas
- Student decline: `Accepted → Submitted`, clears `SupervisorId`, returns proposal to blind pool
- Supervisor sees student name / email / index / batch only for Finalized proposals
- Privacy enforced at query level — identity data only loaded when status is `Finalized`
- `MyProposal.cshtml` updated with confirm/decline handlers and post-Finalized reveal UI

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if this PR touches DB or HTTP)
- [x] Manually verified the feature works end-to-end
- [x] `make test` passes locally
- [x] `dotnet build` succeeds with no new warnings.

**Manual verification:**
- Logged in as a Student with an Accepted proposal — MyProposal shows "A supervisor has expressed interest" with Confirm/Decline buttons, no supervisor identity
- Clicked Confirm — status became Finalized, supervisor details revealed (name, email, department, research areas)
- Logged in as the Supervisor — AcceptedProposals shows student details (name, email, index, batch) for the Finalized row
- Logged in as a different Student, declined the match — proposal returned to Submitted, supervisor dashboard showed it again
- Declined supervisor's identity was never revealed to the student

## Screenshots
<img width="2517" height="1335" alt="vivaldi_WoBf79I8Ag" src="https://github.com/user-attachments/assets/8f316fca-d8a1-40ea-ad22-e901f14aec96" />
<img width="2516" height="1339" alt="vivaldi_UxzeCJvVbD" src="https://github.com/user-attachments/assets/3e2e89e5-1c8b-4b17-b2a3-70b0f72c948d" />

## Checklist

  - [x] Branch named `<type>/<name>-<description>` per CONTRIBUTING.md
  - [x] Commits follow Conventional Commits (`feat:`, `fix:`, etc.)
  - [x] No secrets, passwords, or `.env` contents commited
  - [ ] Migration added if DbContext changed (via `dotnet ef migrations add`)
  - [ ] Related docs updated (CONTRIBUTING.md, README, inline comments)

  ## Closes
  Closes #40