### PR TITLE
feat(admin): manual reassign and override with audit log

### DIFF
--- a/src/Dyadic.Application/Services/IAdminService.cs
+++ b/src/Dyadic.Application/Services/IAdminService.cs
@@ -8,4 +8,8 @@ public interface IAdminService
     Task<DashboardStats> GetDashboardStatsAsync();
     Task<List<Proposal>> GetAllProposalsAsync(bool includeDrafts = false);
     Task<List<SupervisorProfile>> GetAllSupervisorsWithCapacityAsync();
+    Task<List<SupervisorProfile>> GetAvailableSupervisorsAsync(Guid excludeSupervisorId);
+    Task ReassignProposalAsync(Guid proposalId, Guid newSupervisorId, Guid adminUserId, string reason);
+    Task UnmatchProposalAsync(Guid proposalId, Guid adminUserId, string reason);
+    Task<List<AllocationOverride>> GetAuditLogAsync();
 }

--- a/src/Dyadic.Domain/Entities/AllocationOverride.cs
+++ b/src/Dyadic.Domain/Entities/AllocationOverride.cs
@@ -11,7 +11,9 @@ public class AllocationOverride
     public ApplicationUser PerformedBy { get; set; } = null!;
     public OverrideAction Action { get; set; }
     public Guid? OldSupervisorId { get; set; }
+    public SupervisorProfile? OldSupervisor { get; set; }
     public Guid? NewSupervisorId { get; set; }
+    public SupervisorProfile? NewSupervisor { get; set; }
     public string Reason { get; set; } = string.Empty;
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 }

--- a/src/Dyadic.Domain/Entities/AllocationOverride.cs
+++ b/src/Dyadic.Domain/Entities/AllocationOverride.cs
@@ -1,0 +1,17 @@
+using Dyadic.Domain.Enums;
+
+namespace Dyadic.Domain.Entities;
+
+public class AllocationOverride
+{
+    public Guid Id { get; set; }
+    public Guid ProposalId { get; set; }
+    public Proposal Proposal { get; set; } = null!;
+    public Guid PerformedByUserId { get; set; }
+    public ApplicationUser PerformedBy { get; set; } = null!;
+    public OverrideAction Action { get; set; }
+    public Guid? OldSupervisorId { get; set; }
+    public Guid? NewSupervisorId { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}

--- a/src/Dyadic.Domain/Enums/OverrideAction.cs
+++ b/src/Dyadic.Domain/Enums/OverrideAction.cs
@@ -1,0 +1,3 @@
+namespace Dyadic.Domain.Enums;
+
+public enum OverrideAction { Reassign, Unmatch }

--- a/src/Dyadic.Infrastructure/ApplicationDbContext.cs
+++ b/src/Dyadic.Infrastructure/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Dyadic.Domain.Entities;
+using Dyadic.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -12,6 +13,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
     public DbSet<StudentProfile> StudentProfiles => Set<StudentProfile>();
     public DbSet<SupervisorProfile> SupervisorProfiles => Set<SupervisorProfile>();
     public DbSet<Proposal> Proposals => Set<Proposal>();
+    public DbSet<AllocationOverride> AllocationOverrides => Set<AllocationOverride>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) {
         base.OnModelCreating(modelBuilder);
@@ -43,6 +45,24 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
         // ProposalStatus as string in DB
         modelBuilder.Entity<Proposal>()
             .Property(p => p.Status)
+            .HasConversion<string>();
+
+        // AllocationOverride FKs
+        modelBuilder.Entity<AllocationOverride>()
+            .HasOne(a => a.Proposal)
+            .WithMany()
+            .HasForeignKey(a => a.ProposalId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        modelBuilder.Entity<AllocationOverride>()
+            .HasOne(a => a.PerformedBy)
+            .WithMany()
+            .HasForeignKey(a => a.PerformedByUserId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        // OverrideAction as string in DB
+        modelBuilder.Entity<AllocationOverride>()
+            .Property(a => a.Action)
             .HasConversion<string>();
     }
 }

--- a/src/Dyadic.Infrastructure/ApplicationDbContext.cs
+++ b/src/Dyadic.Infrastructure/ApplicationDbContext.cs
@@ -60,6 +60,18 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
             .HasForeignKey(a => a.PerformedByUserId)
             .OnDelete(DeleteBehavior.NoAction);
 
+        modelBuilder.Entity<AllocationOverride>()
+            .HasOne(a => a.OldSupervisor)
+            .WithMany()
+            .HasForeignKey(a => a.OldSupervisorId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        modelBuilder.Entity<AllocationOverride>()
+            .HasOne(a => a.NewSupervisor)
+            .WithMany()
+            .HasForeignKey(a => a.NewSupervisorId)
+            .OnDelete(DeleteBehavior.NoAction);
+
         // OverrideAction as string in DB
         modelBuilder.Entity<AllocationOverride>()
             .Property(a => a.Action)

--- a/src/Dyadic.Infrastructure/Migrations/20260419050736_AddAllocationOverride.Designer.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419050736_AddAllocationOverride.Designer.cs
@@ -4,6 +4,7 @@ using Dyadic.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dyadic.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419050736_AddAllocationOverride")]
+    partial class AddAllocationOverride
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dyadic.Infrastructure/Migrations/20260419050736_AddAllocationOverride.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419050736_AddAllocationOverride.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dyadic.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAllocationOverride : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AllocationOverrides",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ProposalId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PerformedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Action = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    OldSupervisorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    NewSupervisorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Reason = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AllocationOverrides", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AllocationOverrides_AspNetUsers_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_AllocationOverrides_Proposals_ProposalId",
+                        column: x => x.ProposalId,
+                        principalTable: "Proposals",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AllocationOverrides_PerformedByUserId",
+                table: "AllocationOverrides",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AllocationOverrides_ProposalId",
+                table: "AllocationOverrides",
+                column: "ProposalId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AllocationOverrides");
+        }
+    }
+}

--- a/src/Dyadic.Infrastructure/Migrations/20260419051917_AddOverrideSupervisorNavigations.Designer.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419051917_AddOverrideSupervisorNavigations.Designer.cs
@@ -4,6 +4,7 @@ using Dyadic.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dyadic.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419051917_AddOverrideSupervisorNavigations")]
+    partial class AddOverrideSupervisorNavigations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dyadic.Infrastructure/Migrations/20260419051917_AddOverrideSupervisorNavigations.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419051917_AddOverrideSupervisorNavigations.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dyadic.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOverrideSupervisorNavigations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AllocationOverrides_NewSupervisorId",
+                table: "AllocationOverrides",
+                column: "NewSupervisorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AllocationOverrides_OldSupervisorId",
+                table: "AllocationOverrides",
+                column: "OldSupervisorId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AllocationOverrides_SupervisorProfiles_NewSupervisorId",
+                table: "AllocationOverrides",
+                column: "NewSupervisorId",
+                principalTable: "SupervisorProfiles",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AllocationOverrides_SupervisorProfiles_OldSupervisorId",
+                table: "AllocationOverrides",
+                column: "OldSupervisorId",
+                principalTable: "SupervisorProfiles",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AllocationOverrides_SupervisorProfiles_NewSupervisorId",
+                table: "AllocationOverrides");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_AllocationOverrides_SupervisorProfiles_OldSupervisorId",
+                table: "AllocationOverrides");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AllocationOverrides_NewSupervisorId",
+                table: "AllocationOverrides");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AllocationOverrides_OldSupervisorId",
+                table: "AllocationOverrides");
+        }
+    }
+}

--- a/src/Dyadic.Infrastructure/Services/AdminService.cs
+++ b/src/Dyadic.Infrastructure/Services/AdminService.cs
@@ -52,4 +52,78 @@ public class AdminService : IAdminService
             .OrderBy(sp => sp.User.FullName)
             .ToListAsync();
     }
+
+    public async Task<List<SupervisorProfile>> GetAvailableSupervisorsAsync(Guid excludeSupervisorId)
+    {
+        return await _db.SupervisorProfiles
+            .Include(sp => sp.User)
+            .Include(sp => sp.AcceptedProposals)
+            .Where(sp => sp.Id != excludeSupervisorId &&
+                         sp.AcceptedProposals.Count < sp.MaxStudents)
+            .OrderBy(sp => sp.User.FullName)
+            .ToListAsync();
+    }
+
+    public async Task ReassignProposalAsync(Guid proposalId, Guid newSupervisorId, Guid adminUserId, string reason)
+    {
+        var proposal = await _db.Proposals.FindAsync(proposalId)
+            ?? throw new InvalidOperationException("Proposal not found.");
+
+        var newSupervisor = await _db.SupervisorProfiles
+            .Include(sp => sp.AcceptedProposals)
+            .FirstOrDefaultAsync(sp => sp.Id == newSupervisorId)
+            ?? throw new InvalidOperationException("Supervisor not found.");
+
+        if (newSupervisor.AcceptedProposals.Count >= newSupervisor.MaxStudents)
+            throw new InvalidOperationException("The selected supervisor is at maximum capacity.");
+
+        var audit = new AllocationOverride
+        {
+            ProposalId        = proposalId,
+            PerformedByUserId = adminUserId,
+            Action            = OverrideAction.Reassign,
+            OldSupervisorId   = proposal.SupervisorId,
+            NewSupervisorId   = newSupervisorId,
+            Reason            = reason,
+            Timestamp         = DateTime.UtcNow
+        };
+
+        proposal.SupervisorId = newSupervisorId;
+        proposal.Status       = ProposalStatus.Accepted;
+
+        _db.AllocationOverrides.Add(audit);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task UnmatchProposalAsync(Guid proposalId, Guid adminUserId, string reason)
+    {
+        var proposal = await _db.Proposals.FindAsync(proposalId)
+            ?? throw new InvalidOperationException("Proposal not found.");
+
+        var audit = new AllocationOverride
+        {
+            ProposalId        = proposalId,
+            PerformedByUserId = adminUserId,
+            Action            = OverrideAction.Unmatch,
+            OldSupervisorId   = proposal.SupervisorId,
+            NewSupervisorId   = null,
+            Reason            = reason,
+            Timestamp         = DateTime.UtcNow
+        };
+
+        proposal.SupervisorId = null;
+        proposal.Status       = ProposalStatus.Submitted;
+
+        _db.AllocationOverrides.Add(audit);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task<List<AllocationOverride>> GetAuditLogAsync()
+    {
+        return await _db.AllocationOverrides
+            .Include(a => a.Proposal)
+            .Include(a => a.PerformedBy)
+            .OrderByDescending(a => a.Timestamp)
+            .ToListAsync();
+    }
 }

--- a/src/Dyadic.Infrastructure/Services/AdminService.cs
+++ b/src/Dyadic.Infrastructure/Services/AdminService.cs
@@ -123,6 +123,8 @@ public class AdminService : IAdminService
         return await _db.AllocationOverrides
             .Include(a => a.Proposal)
             .Include(a => a.PerformedBy)
+            .Include(a => a.OldSupervisor).ThenInclude(s => s!.User)
+            .Include(a => a.NewSupervisor).ThenInclude(s => s!.User)
             .OrderByDescending(a => a.Timestamp)
             .ToListAsync();
     }

--- a/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml
@@ -21,6 +21,8 @@
                         <th>Admin</th>
                         <th>Action</th>
                         <th>Proposal</th>
+                        <th>Old Supervisor</th>
+                        <th>New Supervisor</th>
                         <th>Reason</th>
                     </tr>
                 </thead>
@@ -33,6 +35,8 @@
                             <td>@entry.PerformedBy.FullName</td>
                             <td><span class="badge @actionBadge">@entry.Action</span></td>
                             <td>@entry.Proposal.Title</td>
+                            <td>@(entry.OldSupervisor != null ? entry.OldSupervisor.User.FullName : "—")</td>
+                            <td>@(entry.NewSupervisor != null ? entry.NewSupervisor.User.FullName : "—")</td>
                             <td>@entry.Reason</td>
                         </tr>
                     }

--- a/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml
@@ -1,0 +1,47 @@
+@page
+@model Dyadic.Web.Pages.Admin.AuditLogModel
+@{
+    ViewData["Title"] = "Audit Log";
+}
+
+<div class="container py-4">
+    <h2 class="mb-4">Audit Log</h2>
+
+    @if (!Model.Entries.Any())
+    {
+        <p class="text-muted">No override actions recorded yet.</p>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-secondary">
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>Admin</th>
+                        <th>Action</th>
+                        <th>Proposal</th>
+                        <th>Reason</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var entry in Model.Entries)
+                    {
+                        var actionBadge = entry.Action.ToString() == "Reassign" ? "bg-success" : "bg-danger";
+                        <tr>
+                            <td>@entry.Timestamp.ToLocalTime().ToString("dd MMM yyyy HH:mm")</td>
+                            <td>@entry.PerformedBy.FullName</td>
+                            <td><span class="badge @actionBadge">@entry.Action</span></td>
+                            <td>@entry.Proposal.Title</td>
+                            <td>@entry.Reason</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+
+    <div class="mt-3">
+        <a asp-page="/Admin/Dashboard" class="btn btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</div>

--- a/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Admin/AuditLog.cshtml.cs
@@ -1,0 +1,24 @@
+using Dyadic.Application.Services;
+using Dyadic.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dyadic.Web.Pages.Admin;
+
+[Authorize(Roles = "Admin")]
+public class AuditLogModel : PageModel
+{
+    private readonly IAdminService _adminService;
+
+    public AuditLogModel(IAdminService adminService)
+    {
+        _adminService = adminService;
+    }
+
+    public List<AllocationOverride> Entries { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        Entries = await _adminService.GetAuditLogAsync();
+    }
+}

--- a/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml
@@ -7,6 +7,15 @@
 <div class="container py-4">
     <h2 class="mb-4">Admin Dashboard</h2>
 
+    @if (TempData["Success"] != null)
+    {
+        <div class="alert alert-success">@TempData["Success"]</div>
+    }
+    @if (TempData["Error"] != null)
+    {
+        <div class="alert alert-danger">@TempData["Error"]</div>
+    }
+
     <div class="row g-3 mb-4">
         <div class="col-6 col-md-3">
             <div class="card text-center border-success">
@@ -77,6 +86,7 @@
                         <th>Status</th>
                         <th>Supervisor</th>
                         <th>Date</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -100,6 +110,25 @@
                             </td>
                             <td>@(proposal.Supervisor != null ? proposal.Supervisor.User.FullName : "—")</td>
                             <td>@proposal.CreatedAt.ToLocalTime().ToString("dd MMM yyyy")</td>
+                            <td>
+                                @if (proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Accepted ||
+                                     proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Finalized)
+                                {
+                                    <button class="btn btn-sm btn-outline-success me-1"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#reassignModal"
+                                            data-proposal-id="@proposal.Id"
+                                            data-supervisor-id="@proposal.SupervisorId">
+                                        Reassign
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-danger"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#unmatchModal"
+                                            data-proposal-id="@proposal.Id">
+                                        Unmatch
+                                    </button>
+                                }
+                            </td>
                         </tr>
                     }
                 </tbody>
@@ -107,7 +136,82 @@
         </div>
     }
 
-    <div class="mt-3">
+    <div class="mt-3 d-flex gap-2">
         <a asp-page="/Admin/Supervisors" class="btn btn-outline-success">View Supervisor Capacity</a>
+        <a asp-page="/Admin/AuditLog" class="btn btn-outline-secondary">View Audit Log</a>
     </div>
 </div>
+
+<!-- Reassign Modal -->
+<div class="modal fade" id="reassignModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" asp-page-handler="Reassign">
+                <div class="modal-header">
+                    <h5 class="modal-title">Reassign Proposal</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="ProposalId" id="reassignProposalId" />
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">New Supervisor</label>
+                        <select name="NewSupervisorId" class="form-select" required>
+                            <option value="">— Select supervisor —</option>
+                            @foreach (var supervisor in Model.AvailableSupervisors)
+                            {
+                                <option value="@supervisor.Id">
+                                    @supervisor.User.FullName (@supervisor.AcceptedProposals.Count/@supervisor.MaxStudents)
+                                </option>
+                            }
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Reason <span class="text-muted small">(min 10 characters)</span></label>
+                        <textarea name="Reason" class="form-control" rows="3" maxlength="500" required minlength="10"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-success">Reassign</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Unmatch Modal -->
+<div class="modal fade" id="unmatchModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" asp-page-handler="Unmatch">
+                <div class="modal-header">
+                    <h5 class="modal-title">Unmatch Proposal</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="ProposalId" id="unmatchProposalId" />
+                    <p class="text-muted small">This will return the proposal to Submitted status and clear the supervisor assignment.</p>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Reason <span class="text-muted small">(min 10 characters)</span></label>
+                        <textarea name="Reason" class="form-control" rows="3" maxlength="500" required minlength="10"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Unmatch</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.getElementById('reassignModal').addEventListener('show.bs.modal', function (e) {
+            document.getElementById('reassignProposalId').value = e.relatedTarget.dataset.proposalId;
+        });
+        document.getElementById('unmatchModal').addEventListener('show.bs.modal', function (e) {
+            document.getElementById('unmatchProposalId').value = e.relatedTarget.dataset.proposalId;
+        });
+    </script>
+}

--- a/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml.cs
@@ -2,8 +2,10 @@ using Dyadic.Application.DTOs;
 using Dyadic.Application.Services;
 using Dyadic.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.ComponentModel.DataAnnotations;
 
 namespace Dyadic.Web.Pages.Admin;
 
@@ -11,21 +13,87 @@ namespace Dyadic.Web.Pages.Admin;
 public class DashboardModel : PageModel
 {
     private readonly IAdminService _adminService;
+    private readonly UserManager<ApplicationUser> _userManager;
 
-    public DashboardModel(IAdminService adminService)
+    public DashboardModel(IAdminService adminService, UserManager<ApplicationUser> userManager)
     {
         _adminService = adminService;
+        _userManager = userManager;
     }
 
     public DashboardStats Stats { get; set; } = new();
     public List<Proposal> Proposals { get; set; } = new();
+    public List<SupervisorProfile> AvailableSupervisors { get; set; } = new();
 
     [BindProperty(SupportsGet = true)]
     public bool ShowDrafts { get; set; }
+
+    [BindProperty]
+    public Guid ProposalId { get; set; }
+
+    [BindProperty]
+    public Guid NewSupervisorId { get; set; }
+
+    [BindProperty]
+    [Required(ErrorMessage = "Reason is required.")]
+    [StringLength(500, MinimumLength = 10, ErrorMessage = "Reason must be between 10 and 500 characters.")]
+    public string Reason { get; set; } = string.Empty;
 
     public async Task OnGetAsync()
     {
         Stats = await _adminService.GetDashboardStatsAsync();
         Proposals = await _adminService.GetAllProposalsAsync(ShowDrafts);
+        AvailableSupervisors = await _adminService.GetAllSupervisorsWithCapacityAsync();
+    }
+
+    public async Task<IActionResult> OnPostReassignAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadPageData();
+            return Page();
+        }
+
+        try
+        {
+            var adminId = Guid.Parse(_userManager.GetUserId(User)!);
+            await _adminService.ReassignProposalAsync(ProposalId, NewSupervisorId, adminId, Reason);
+            TempData["Success"] = "Proposal reassigned successfully.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostUnmatchAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadPageData();
+            return Page();
+        }
+
+        try
+        {
+            var adminId = Guid.Parse(_userManager.GetUserId(User)!);
+            await _adminService.UnmatchProposalAsync(ProposalId, adminId, Reason);
+            TempData["Success"] = "Proposal unmatched successfully.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+
+        return RedirectToPage();
+    }
+
+    private async Task LoadPageData()
+    {
+        Stats = await _adminService.GetDashboardStatsAsync();
+        Proposals = await _adminService.GetAllProposalsAsync(ShowDrafts);
+        AvailableSupervisors = await _adminService.GetAllSupervisorsWithCapacityAsync();
     }
 }

--- a/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
@@ -49,6 +49,9 @@
                             <li class="nav-item">
                                 <a class="nav-link text-white" asp-page="/Admin/Supervisors">Supervisors</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-white" asp-page="/Admin/AuditLog">Audit Log</a>
+                            </li>
                         }
                         else if (SignInManager.IsSignedIn(User))
                         {


### PR DESCRIPTION
## Summary
  - Adds `AllocationOverride` entity and `OverrideAction` enum to track every admin intervention
  - Admin dashboard gains **Reassign** and **Unmatch** modals for Accepted/Finalized proposals, with required reason validation (min 10 chars)
  - New **Audit Log** page shows all overrides ordered most recent first (timestamp, admin, action, old/new supervisor, reason)
  - Rebased onto merged PR #44 — preserves SQL-side `GroupBy` stats and `ShowDrafts` checkbox

  ## Changes
  - `Domain`: new `AllocationOverride` entity, `OverrideAction` enum (`Reassign`, `Unmatch`)
  - `Application`: `IAdminService` extended with `ReassignProposalAsync`, `UnmatchProposalAsync`, `GetAvailableSupervisorsAsync`, `GetAuditLogAsync`
  - `Infrastructure`: `AdminService` implements override logic with capacity check, atomic audit row creation; migrations `AddAllocationOverride` + `AddOverrideSupervisorNavigations`
  - `Web`: Admin Dashboard Reassign/Unmatch Bootstrap modals; new `/Admin/AuditLog` page; Audit Log nav link added

  ## Testing
  - [x] Log in as Admin
  - [x] Reassign an Accepted proposal to a different supervisor — status stays Accepted, new supervisor shown
  - [x] Unmatch a proposal — status returns to Submitted, supervisor cleared
  - [x] Try reassigning to a full supervisor — error message shown
  - [x] Submit empty/short reason — form blocked by validation
  - [x] Audit Log page shows all overrides with correct old/new supervisor names

  ## Screenshots
<img width="2511" height="1326" alt="vivaldi_geCnpqBPrm" src="https://github.com/user-attachments/assets/4e95ab18-c7bd-4c5b-a7d9-4c129ca8d2e5" />
<img width="2516" height="1326" alt="vivaldi_PvXfV9YFek" src="https://github.com/user-attachments/assets/4961050f-3510-4714-b09e-6bd78151d13b" />

  ## Checklist
  - [x] Rebased onto latest main
  - [x] Build passes
  - [x] No regression of PR #44 fixes (SQL GroupBy, ShowDrafts checkbox)
  - [x] Audit rows are immutable (insert-only, no update/delete)
  - [x] Admin identity sourced from server-side `UserManager` (tamper-proof)

  ## Closes
  Closes #45