### PR TITLE
feat(student): strengthen proposal form validation

### DIFF
--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
@@ -33,13 +33,25 @@ public class SubmitProposalModel : PageModel
 
     public class InputModel
     {
-        [Required, MaxLength(200)]
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Title is required.")]
+        [MinLength(10, ErrorMessage = "Title must be at least 10 characters.")]
+        [MaxLength(200)]
+        [RegularExpression(@"^[a-zA-Z0-9\s\-.,:;()'""?!]+$",
+            ErrorMessage = "Title contains invalid characters.")]
         public string Title { get; set; } = string.Empty;
 
-        [Required, MaxLength(2000)]
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Abstract is required.")]
+        [MinLength(50, ErrorMessage = "Abstract must be at least 50 characters.")]
+        [MaxLength(2000)]
+        [RegularExpression(@"^[a-zA-Z0-9\s\-.,:;()'""?!\r\n]+$",
+            ErrorMessage = "Abstract contains invalid characters.")]
         public string Abstract { get; set; } = string.Empty;
 
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Tech Stack is required.")]
+        [MinLength(3, ErrorMessage = "Tech Stack must be at least 3 characters.")]
         [MaxLength(500)]
+        [RegularExpression(@"^[a-zA-Z0-9\s\-.,+#/()]+$",
+            ErrorMessage = "Tech Stack contains invalid characters.")]
         public string TechStack { get; set; } = string.Empty;
 
         [Required(ErrorMessage = "Please select a research area.")]
@@ -73,10 +85,27 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostDraftAsync()
     {
+        Input.Title = Input.Title.Trim();
+        Input.Abstract = Input.Abstract.Trim();
+        Input.TechStack = Input.TechStack.Trim();
+        ModelState.Clear();
+        TryValidateModel(Input, nameof(Input));
+
         if (!ModelState.IsValid)
         {
             await LoadResearchAreas();
             return Page();
+        }
+
+        if (Input.ResearchAreaId.HasValue)
+        {
+            var areas = await _researchAreaService.GetActiveAsync();
+            if (!areas.Any(a => a.Id == Input.ResearchAreaId.Value))
+            {
+                ModelState.AddModelError("Input.ResearchAreaId", "Invalid research area.");
+                await LoadResearchAreas();
+                return Page();
+            }
         }
 
         var user = await _userManager.GetUserAsync(User);
@@ -95,10 +124,27 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostSubmitAsync()
     {
+        Input.Title = Input.Title.Trim();
+        Input.Abstract = Input.Abstract.Trim();
+        Input.TechStack = Input.TechStack.Trim();
+        ModelState.Clear();
+        TryValidateModel(Input, nameof(Input));
+
         if (!ModelState.IsValid)
         {
             await LoadResearchAreas();
             return Page();
+        }
+
+        if (Input.ResearchAreaId.HasValue)
+        {
+            var areas = await _researchAreaService.GetActiveAsync();
+            if (!areas.Any(a => a.Id == Input.ResearchAreaId.Value))
+            {
+                ModelState.AddModelError("Input.ResearchAreaId", "Invalid research area.");
+                await LoadResearchAreas();
+                return Page();
+            }
         }
 
         var user = await _userManager.GetUserAsync(User);

--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
@@ -85,9 +85,9 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostDraftAsync()
     {
-        Input.Title = Input.Title.Trim();
-        Input.Abstract = Input.Abstract.Trim();
-        Input.TechStack = Input.TechStack.Trim();
+        Input.Title = (Input.Title ?? string.Empty).Trim();
+        Input.Abstract = (Input.Abstract ?? string.Empty).Trim();
+        Input.TechStack = (Input.TechStack ?? string.Empty).Trim();
         ModelState.Clear();
         TryValidateModel(Input, nameof(Input));
 
@@ -124,9 +124,9 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostSubmitAsync()
     {
-        Input.Title = Input.Title.Trim();
-        Input.Abstract = Input.Abstract.Trim();
-        Input.TechStack = Input.TechStack.Trim();
+        Input.Title = (Input.Title ?? string.Empty).Trim();
+        Input.Abstract = (Input.Abstract ?? string.Empty).Trim();
+        Input.TechStack = (Input.TechStack ?? string.Empty).Trim();
         ModelState.Clear();
         TryValidateModel(Input, nameof(Input));
 

--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml.cs
@@ -85,27 +85,10 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostDraftAsync()
     {
-        Input.Title = (Input.Title ?? string.Empty).Trim();
-        Input.Abstract = (Input.Abstract ?? string.Empty).Trim();
-        Input.TechStack = (Input.TechStack ?? string.Empty).Trim();
-        ModelState.Clear();
-        TryValidateModel(Input, nameof(Input));
-
-        if (!ModelState.IsValid)
+        if (!await ValidateInputAsync())
         {
             await LoadResearchAreas();
             return Page();
-        }
-
-        if (Input.ResearchAreaId.HasValue)
-        {
-            var areas = await _researchAreaService.GetActiveAsync();
-            if (!areas.Any(a => a.Id == Input.ResearchAreaId.Value))
-            {
-                ModelState.AddModelError("Input.ResearchAreaId", "Invalid research area.");
-                await LoadResearchAreas();
-                return Page();
-            }
         }
 
         var user = await _userManager.GetUserAsync(User);
@@ -124,27 +107,10 @@ public class SubmitProposalModel : PageModel
 
     public async Task<IActionResult> OnPostSubmitAsync()
     {
-        Input.Title = (Input.Title ?? string.Empty).Trim();
-        Input.Abstract = (Input.Abstract ?? string.Empty).Trim();
-        Input.TechStack = (Input.TechStack ?? string.Empty).Trim();
-        ModelState.Clear();
-        TryValidateModel(Input, nameof(Input));
-
-        if (!ModelState.IsValid)
+        if (!await ValidateInputAsync())
         {
             await LoadResearchAreas();
             return Page();
-        }
-
-        if (Input.ResearchAreaId.HasValue)
-        {
-            var areas = await _researchAreaService.GetActiveAsync();
-            if (!areas.Any(a => a.Id == Input.ResearchAreaId.Value))
-            {
-                ModelState.AddModelError("Input.ResearchAreaId", "Invalid research area.");
-                await LoadResearchAreas();
-                return Page();
-            }
         }
 
         var user = await _userManager.GetUserAsync(User);
@@ -160,6 +126,28 @@ public class SubmitProposalModel : PageModel
 
         await _proposalService.SubmitAsync(existing.Id);
         return RedirectToPage("/Student/MyProposal");
+    }
+
+    private async Task<bool> ValidateInputAsync()
+    {
+        Input.Title = (Input.Title ?? string.Empty).Trim();
+        Input.Abstract = (Input.Abstract ?? string.Empty).Trim();
+        Input.TechStack = (Input.TechStack ?? string.Empty).Trim();
+        ModelState.Clear();
+        TryValidateModel(Input, nameof(Input));
+
+        if (!ModelState.IsValid) return false;
+
+        if (Input.ResearchAreaId is Guid areaId)
+        {
+            var areas = await _researchAreaService.GetActiveAsync();
+            if (!areas.Any(a => a.Id == areaId))
+            {
+                ModelState.AddModelError("Input.ResearchAreaId", "Invalid research area.");
+                return false;
+            }
+        }
+        return true;
     }
 
     private async Task LoadResearchAreas()


### PR DESCRIPTION
## Summary
  - Adds `[Required(AllowEmptyStrings = false)]`, `[MinLength]`, and `[RegularExpression]` to all text fields on the student proposal form
  - Server-side trim before validation so whitespace-only input is rejected even if it meets min length
  - Server-side ResearchArea whitelist check against active DB areas to prevent tampered form submissions

  ## Changes
  - `SubmitProposal.cshtml.cs` — strengthened `InputModel` with regex + min length on Title, Abstract, TechStack; trim → re-validate pattern in both `OnPostDraftAsync` and `OnPostSubmitAsync`

  ## Testing
  - [x] Submit whitespace-only title — rejected
  - [x] Submit title shorter than 10 chars — rejected
  - [x] Submit `<script>alert(1)</script>` in title — rejected by regex
  - [x] Submit emoji in title — rejected by regex
  - [x] Submit valid proposal — accepted and saved
  - [x] Tamper ResearchAreaId via DevTools to invalid GUID — rejected server-side
  - [x] `dotnet build` passes with no warnings

  ## Checklist
  - [x] `[Required(AllowEmptyStrings = false)]` on all text fields
  - [x] `[MinLength]` on Title (10), Abstract (50), TechStack (3)
  - [x] `[RegularExpression]` patterns with clear error messages
  - [x] Server-side trim before persistence
  - [x] ResearchArea validated against active DB areas
  - [x] Build clean

  ## Closes
  Closes #48