### PR TITLE
fix(web): separate Audit Log and Research Areas nav items

### DIFF
--- a/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
@@ -51,6 +51,8 @@
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link text-white" asp-page="/Admin/AuditLog">Audit Log</a>
+                            </li>
+                            <li class="nav-item">
                                 <a class="nav-link text-white" asp-page="/Admin/ResearchAreas">Research Areas</a>
                             </li>
                         }


### PR DESCRIPTION
## Summary

Navbar had both admin links (`Audit Log` and `Research Areas`) stuffed inside a single `<li>`, so they rendered side-by-side instead of as separate nav items. Splits them into two `<li>` elements.

## Changes

<!-- Bullet list of notable changes. -->
- Split the two `<a>` tags in `_Layout.cshtml` into their own `<li class="nav-item">` wrappers

## Testing
<!-- How did you verify this works? What should Dwain run? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if this PR touches DB or HTTP)
- [x] Manually verified the feature works end-to-end
- [x] `make test` passes locally
- [x] `dotnet build` succeeds with no new warnings.

## Screenshots
<img width="2510" height="1330" alt="vivaldi_D5zpOpvCgI" src="https://github.com/user-attachments/assets/b1ba6d1c-e87e-4060-8c9f-a41a1c5a0806" />

## Checklist
- [x] Branch named `<type>/<name>-<description>` per CONTRIBUTING.md
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, etc.)
- [x] No secrets, passwords, or `.env` contents commited
- [ ] Migration added if DbContext changed (via `dotnet ef migrations add`)
- [ ] Related docs updated (CONTRIBUTING.md, README, inline comments)

## Closes

Follow-up fix for #49 (navbar rendering).