### PR TITLE
feat(student): show awaiting-supervisor placeholder on MyProposal

### DIFF
--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
@@ -47,6 +47,10 @@
 
             @if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Draft)
             {
+                <div class="alert alert-warning mt-3">
+                    <strong>&#9998; Draft — not yet submitted.</strong><br />
+                    Your proposal is saved but hasn't been sent to the supervisor pool yet. Click <em>Submit Proposal</em> when you're ready.
+                </div>
                 <div class="d-flex gap-2">
                     <a asp-page="/Student/SubmitProposal" class="btn btn-outline-secondary">Edit Draft</a>
                     <a asp-page="/Student/SubmitProposal" class="btn btn-success">Submit Proposal</a>
@@ -54,6 +58,10 @@
             }
             else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Submitted)
             {
+                <div class="alert alert-info mt-3">
+                    <strong>&#8987; Awaiting supervisor interest</strong><br />
+                    Your proposal has been submitted to the supervisor pool. A supervisor will review it and reach out if they're interested — you'll see a confirmation request here when that happens.
+                </div>
                 <form method="post">
                     <button type="submit" asp-page-handler="Withdraw"
                             class="btn btn-outline-danger"


### PR DESCRIPTION
## Summary
  - Adds a visually distinct status card on `/Student/MyProposal` for `Submitted` and `Draft` states so students understand what's happening with their proposal

  ## Changes
  - `MyProposal.cshtml` — `Submitted` status shows a blue `alert-info` card with hourglass icon explaining the proposal is in the supervisor pool; `Draft` status shows a yellow
  `alert-warning` card prompting the student to submit

  ## Testing
  - [x] Student with a Draft proposal sees the yellow "not yet submitted" card with Edit/Submit buttons below
  - [x] Student with a Submitted proposal sees the blue "Awaiting supervisor interest" card with Withdraw button below
  - [x] No supervisor identity revealed on the Submitted card
  - [x] Accepted, Finalized states unchanged
  - [x] `dotnet build` passes with no warnings

  ## Screenshots
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 17 11 00" src="https://github.com/user-attachments/assets/eae7b14f-6e52-4a97-bdd2-9c9afe8d815a" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 17 11 06" src="https://github.com/user-attachments/assets/42cbf438-25c1-4668-b510-b663d9c02b54" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 17 12 37" src="https://github.com/user-attachments/assets/3fcbea5f-1e3d-4796-865b-536bb76beadc" />



  ## Checklist
  - [x] Submitted state shows visually distinct card with explanatory text
  - [x] Draft state shows equivalent placeholder
  - [x] Withdraw button still visible and functional on Submitted view
  - [x] No backend changes — pure Razor presentation
  - [x] Build clean

  ## Closes
  Closes #52