### PR TITLE
feat(admin): admin user management - list, role change, deactivate/reactivate

### DIFF
--- a/src/Dyadic.Application/DTOs/UserListItem.cs
+++ b/src/Dyadic.Application/DTOs/UserListItem.cs
@@ -1,0 +1,11 @@
+namespace Dyadic.Application.DTOs;
+
+public class UserListItem
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Dyadic.Application/Services/IUserAdminService.cs
+++ b/src/Dyadic.Application/Services/IUserAdminService.cs
@@ -1,0 +1,11 @@
+using Dyadic.Application.DTOs;
+
+namespace Dyadic.Application.Services;
+
+public interface IUserAdminService
+{
+    Task<List<UserListItem>> GetAllUsersAsync();
+    Task ChangeRoleAsync(Guid userId, string newRole, Guid requestingAdminId);
+    Task DeactivateAsync(Guid userId, Guid requestingAdminId);
+    Task ReactivateAsync(Guid userId);
+}

--- a/src/Dyadic.Domain/Entities/ApplicationUser.cs
+++ b/src/Dyadic.Domain/Entities/ApplicationUser.cs
@@ -5,6 +5,7 @@ namespace Dyadic.Domain.Entities;
 public class ApplicationUser: IdentityUser<Guid> {
     public required string FullName { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool IsActive { get; set; } = true;
 
     public StudentProfile? StudentProfile { get; set; }
     public SupervisorProfile? SupervisorProfile { get; set; } 

--- a/src/Dyadic.Infrastructure/Migrations/20260419133835_AddUserIsActive.Designer.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419133835_AddUserIsActive.Designer.cs
@@ -4,6 +4,7 @@ using Dyadic.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dyadic.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419133835_AddUserIsActive")]
+    partial class AddUserIsActive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dyadic.Infrastructure/Migrations/20260419133835_AddUserIsActive.cs
+++ b/src/Dyadic.Infrastructure/Migrations/20260419133835_AddUserIsActive.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dyadic.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserIsActive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.Sql("UPDATE [AspNetUsers] SET [IsActive] = 1");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/src/Dyadic.Infrastructure/Services/UserAdminService.cs
+++ b/src/Dyadic.Infrastructure/Services/UserAdminService.cs
@@ -1,0 +1,91 @@
+using Dyadic.Application.DTOs;
+using Dyadic.Application.Services;
+using Dyadic.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dyadic.Infrastructure.Services;
+
+public class UserAdminService : IUserAdminService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public UserAdminService(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<List<UserListItem>> GetAllUsersAsync()
+    {
+        var users = await _userManager.Users
+            .OrderBy(u => u.FullName)
+            .ToListAsync();
+
+        var result = new List<UserListItem>();
+        foreach (var user in users)
+        {
+            var roles = await _userManager.GetRolesAsync(user);
+            result.Add(new UserListItem
+            {
+                Id        = user.Id,
+                FullName  = user.FullName,
+                Email     = user.Email ?? string.Empty,
+                Role      = roles.FirstOrDefault() ?? "—",
+                IsActive  = user.IsActive,
+                CreatedAt = user.CreatedAt
+            });
+        }
+        return result;
+    }
+
+    public async Task ChangeRoleAsync(Guid userId, string newRole, Guid requestingAdminId)
+    {
+        if (userId == requestingAdminId)
+            throw new InvalidOperationException("You cannot change your own role.");
+
+        var user = await _userManager.FindByIdAsync(userId.ToString())
+            ?? throw new InvalidOperationException("User not found.");
+
+        if (newRole != "Admin")
+        {
+            var admins = await _userManager.GetUsersInRoleAsync("Admin");
+            if (admins.Count == 1 && admins[0].Id == userId)
+                throw new InvalidOperationException("Cannot remove the last administrator.");
+        }
+
+        var currentRoles = await _userManager.GetRolesAsync(user);
+        var removeResult = await _userManager.RemoveFromRolesAsync(user, currentRoles);
+        if (!removeResult.Succeeded)
+            throw new InvalidOperationException("Failed to remove existing role.");
+
+        var addResult = await _userManager.AddToRoleAsync(user, newRole);
+        if (!addResult.Succeeded)
+        {
+            // Restore original role on failure
+            if (currentRoles.Any())
+                await _userManager.AddToRoleAsync(user, currentRoles.First());
+            throw new InvalidOperationException("Failed to assign new role.");
+        }
+    }
+
+    public async Task DeactivateAsync(Guid userId, Guid requestingAdminId)
+    {
+        if (userId == requestingAdminId)
+            throw new InvalidOperationException("You cannot deactivate your own account.");
+
+        var user = await _userManager.FindByIdAsync(userId.ToString())
+            ?? throw new InvalidOperationException("User not found.");
+
+        user.IsActive = false;
+        await _userManager.UpdateAsync(user);
+    }
+
+    public async Task ReactivateAsync(Guid userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString())
+            ?? throw new InvalidOperationException("User not found.");
+
+        user.IsActive = true;
+        await _userManager.UpdateAsync(user);
+    }
+}

--- a/src/Dyadic.Web/Pages/Account/Login.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Account/Login.cshtml.cs
@@ -9,10 +9,12 @@ namespace Dyadic.Web.Pages.Account;
 public class LoginModel : PageModel
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly UserManager<ApplicationUser> _userManager;
 
-    public LoginModel(SignInManager<ApplicationUser> signInManager)
+    public LoginModel(SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager)
     {
         _signInManager = signInManager;
+        _userManager = userManager;
     }
 
     [BindProperty]
@@ -45,7 +47,16 @@ public class LoginModel : PageModel
             Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
 
         if (result.Succeeded)
+        {
+            var user = await _userManager.FindByEmailAsync(Input.Email);
+            if (user != null && !user.IsActive)
+            {
+                await _signInManager.SignOutAsync();
+                ModelState.AddModelError(string.Empty, "Your account has been deactivated. Contact an administrator.");
+                return Page();
+            }
             return LocalRedirect(returnUrl ?? "/Dashboard");
+        }
 
         ModelState.AddModelError(string.Empty, "Invalid login attempt.");
         return Page();

--- a/src/Dyadic.Web/Pages/Admin/Users.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/Users.cshtml
@@ -1,0 +1,156 @@
+@page
+@model Dyadic.Web.Pages.Admin.UsersModel
+@{
+    ViewData["Title"] = "User Management";
+    var roles = new[] { "Student", "Supervisor", "Admin" };
+}
+
+<div class="container py-4">
+    <h2 class="mb-4">User Management</h2>
+
+    @if (TempData["Error"] != null)
+    {
+        <div class="alert alert-danger">@TempData["Error"]</div>
+    }
+
+    <form method="get" class="row g-2 mb-4">
+        <div class="col-auto">
+            <select name="RoleFilter" class="form-select" onchange="this.form.submit()">
+                <option value="All" selected="@(Model.RoleFilter == "All")">All Roles</option>
+                @foreach (var r in roles)
+                {
+                    <option value="@r" selected="@(Model.RoleFilter == r)">@r</option>
+                }
+            </select>
+        </div>
+        <div class="col-auto">
+            <select name="StatusFilter" class="form-select" onchange="this.form.submit()">
+                <option value="All" selected="@(Model.StatusFilter == "All")">All Statuses</option>
+                <option value="Active" selected="@(Model.StatusFilter == "Active")">Active</option>
+                <option value="Inactive" selected="@(Model.StatusFilter == "Inactive")">Inactive</option>
+            </select>
+        </div>
+    </form>
+
+    @if (!Model.Users.Any())
+    {
+        <p class="text-muted">No users match the selected filters.</p>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-secondary">
+                    <tr>
+                        <th>Full Name</th>
+                        <th>Email</th>
+                        <th>Role</th>
+                        <th>Status</th>
+                        <th>Registered</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var u in Model.Users)
+                    {
+                        var roleBadge = u.Role switch
+                        {
+                            "Admin"      => "bg-danger",
+                            "Supervisor" => "bg-primary",
+                            "Student"    => "bg-success",
+                            _            => "bg-secondary"
+                        };
+                        var isSelf = u.Id == Model.CurrentAdminId;
+                        <tr>
+                            <td>@u.FullName</td>
+                            <td>@u.Email</td>
+                            <td><span class="badge @roleBadge">@u.Role</span></td>
+                            <td>
+                                @if (u.IsActive)
+                                {
+                                    <span class="badge bg-success">Active</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary">Inactive</span>
+                                }
+                            </td>
+                            <td>@u.CreatedAt.ToLocalTime().ToString("dd MMM yyyy")</td>
+                            <td>
+                                @if (!isSelf)
+                                {
+                                    <button type="button"
+                                            class="btn btn-sm btn-outline-primary me-1"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#roleModal-@u.Id">
+                                        Change Role
+                                    </button>
+
+                                    @if (u.IsActive)
+                                    {
+                                        <form method="post" class="d-inline">
+                                            <input type="hidden" name="userId" value="@u.Id" />
+                                            <button type="submit" asp-page-handler="Deactivate"
+                                                    class="btn btn-sm btn-outline-danger"
+                                                    onclick="return confirm('Deactivate @u.FullName? They won\'t be able to log in. Their proposals and audit history remain intact.')">
+                                                Deactivate
+                                            </button>
+                                        </form>
+                                    }
+                                    else
+                                    {
+                                        <form method="post" class="d-inline">
+                                            <input type="hidden" name="userId" value="@u.Id" />
+                                            <button type="submit" asp-page-handler="Reactivate"
+                                                    class="btn btn-sm btn-outline-success">
+                                                Reactivate
+                                            </button>
+                                        </form>
+                                    }
+                                }
+                                else
+                                {
+                                    <span class="text-muted fst-italic small">You</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+
+    <div class="mt-3">
+        <a asp-page="/Admin/Dashboard" class="btn btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</div>
+
+@foreach (var u in Model.Users.Where(u => u.Id != Model.CurrentAdminId))
+{
+    <div class="modal fade" id="roleModal-@u.Id" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Change Role — @u.FullName</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form method="post">
+                    <div class="modal-body">
+                        <input type="hidden" name="userId" value="@u.Id" />
+                        <label class="form-label">New Role</label>
+                        <select name="newRole" class="form-select">
+                            @foreach (var r in new[] { "Student", "Supervisor", "Admin" })
+                            {
+                                <option value="@r" selected="@(u.Role == r)">@r</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" asp-page-handler="ChangeRole" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+}

--- a/src/Dyadic.Web/Pages/Admin/Users.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Admin/Users.cshtml.cs
@@ -1,0 +1,85 @@
+using Dyadic.Application.DTOs;
+using Dyadic.Application.Services;
+using Dyadic.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dyadic.Web.Pages.Admin;
+
+[Authorize(Roles = "Admin")]
+public class UsersModel : PageModel
+{
+    private readonly IUserAdminService _userAdminService;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public UsersModel(IUserAdminService userAdminService, UserManager<ApplicationUser> userManager)
+    {
+        _userAdminService = userAdminService;
+        _userManager = userManager;
+    }
+
+    public List<UserListItem> Users { get; set; } = new();
+    public Guid CurrentAdminId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string RoleFilter { get; set; } = "All";
+
+    [BindProperty(SupportsGet = true)]
+    public string StatusFilter { get; set; } = "All";
+
+    public async Task OnGetAsync()
+    {
+        CurrentAdminId = Guid.Parse(_userManager.GetUserId(User)!);
+        var all = await _userAdminService.GetAllUsersAsync();
+
+        Users = all
+            .Where(u => RoleFilter == "All" || u.Role == RoleFilter)
+            .Where(u => StatusFilter == "All" ||
+                        (StatusFilter == "Active" && u.IsActive) ||
+                        (StatusFilter == "Inactive" && !u.IsActive))
+            .ToList();
+    }
+
+    public async Task<IActionResult> OnPostChangeRoleAsync(Guid userId, string newRole)
+    {
+        var adminId = Guid.Parse(_userManager.GetUserId(User)!);
+        try
+        {
+            await _userAdminService.ChangeRoleAsync(userId, newRole, adminId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostDeactivateAsync(Guid userId)
+    {
+        var adminId = Guid.Parse(_userManager.GetUserId(User)!);
+        try
+        {
+            await _userAdminService.DeactivateAsync(userId, adminId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostReactivateAsync(Guid userId)
+    {
+        try
+        {
+            await _userAdminService.ReactivateAsync(userId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+        return RedirectToPage();
+    }
+}

--- a/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
@@ -55,6 +55,9 @@
                             <li class="nav-item">
                                 <a class="nav-link text-white" asp-page="/Admin/ResearchAreas">Research Areas</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-white" asp-page="/Admin/Users">Users</a>
+                            </li>
                         }
                         else if (SignInManager.IsSignedIn(User))
                         {

--- a/src/Dyadic.Web/Program.cs
+++ b/src/Dyadic.Web/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddScoped<IProposalService, ProposalService>();
 builder.Services.AddScoped<ISupervisorProfileService, SupervisorProfileService>();
 builder.Services.AddScoped<IAdminService, AdminService>();
 builder.Services.AddScoped<IResearchAreaService, ResearchAreaService>();
+builder.Services.AddScoped<IUserAdminService, UserAdminService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
  - Adds `IsActive` flag to `ApplicationUser` for soft-deactivation (preserves FK references)
  - New `/Admin/Users` page — lists all users with role badge, status badge, created date, filters by role and status
  - Change Role modal — atomic remove-all + add-one, with guard rails server-side
  - Deactivate/Reactivate actions — deactivated users are blocked at login with a friendly message
  - Guard rails: admin cannot change own role, deactivate themselves, or demote the last admin

  ## Changes
  - `Domain`: `IsActive bool` property on `ApplicationUser`
  - `Infrastructure`: migration `AddUserIsActive` (default true + UPDATE for existing rows); `UserAdminService` implementation
  - `Application`: `UserListItem` DTO, `IUserAdminService` interface
  - `Web`: `Login.cshtml.cs` — IsActive gate after `PasswordSignInAsync`; `Users.cshtml` + `Users.cshtml.cs`; `Program.cs` — service registration; `_Layout.cshtml` — Users nav link

  ## Testing
  - [x] `/Admin/Users` shows all users with correct columns and badges
  - [x] Role filter and Status filter narrow the list correctly
  - [x] Change Role modal updates the role immediately
  - [x] Deactivated user cannot log in — sees "Your account has been deactivated. Contact an administrator."
  - [x] Reactivated user can log in again
  - [x] Admin row shows "You" label — no action buttons
  - [x] Crafted POST to change own role returns error
  - [x] Crafted POST to demote last admin returns error
  - [x] Non-admin gets 403 on `/Admin/Users`
  - [x] `dotnet build` passes with no warnings

## Screenshots

<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 17 32" src="https://github.com/user-attachments/assets/ddc17dfa-402f-4c53-98ca-7d98f0863a92" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 24 10" src="https://github.com/user-attachments/assets/0640f802-964b-4655-a83b-54078be262c9" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 25 26" src="https://github.com/user-attachments/assets/1e9e4f0c-6d41-4655-9d90-41bbc215dc0a" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 26 14" src="https://github.com/user-attachments/assets/fc65fc8a-418c-48d8-989b-1abe944d6e75" />



  ## Checklist
  - [x] Migration adds `IsActive` with default `true`
  - [x] All existing users set to `IsActive = 1` via SQL UPDATE
  - [x] Guard rails server-side in `UserAdminService` (not just UI)
  - [x] Login gate blocks inactive users after `PasswordSignInAsync`
  - [x] Atomic role change with rollback on failure
  - [x] Build clean, migration applied

  ## Closes
  Closes #56