### PR TITLE
feat(supervisor): filter and sort dashboard by research area

### DIFF
--- a/src/Dyadic.Application/Services/IProposalService.cs
+++ b/src/Dyadic.Application/Services/IProposalService.cs
@@ -10,7 +10,7 @@ public interface IProposalService
     Task<Proposal> SubmitAsync(Guid proposalId);
     Task<Proposal?> GetByStudentIdAsync(Guid studentProfileId);
     Task<Proposal> WithdrawAsync(Guid proposalId, Guid studentProfileId, Guid actorUserId);
-    Task<List<Proposal>> GetSubmittedProposalsAsync();
+    Task<List<Proposal>> GetSubmittedProposalsAsync(Guid? researchAreaId = null, string sort = "Newest");
     Task<Proposal> AcceptProposalAsync(Guid proposalId, Guid supervisorProfileId);
     Task<List<Proposal>> GetAcceptedBySupervisorAsync(Guid supervisorProfileId);
     Task<Proposal> ConfirmMatchAsync(Guid proposalId, Guid studentProfileId, Guid actorUserId);

--- a/src/Dyadic.Infrastructure/Services/ProposalService.cs
+++ b/src/Dyadic.Infrastructure/Services/ProposalService.cs
@@ -134,13 +134,18 @@ public class ProposalService : IProposalService
         return proposal;
     }
 
-    public async Task<List<Proposal>> GetSubmittedProposalsAsync()
+    public async Task<List<Proposal>> GetSubmittedProposalsAsync(Guid? researchAreaId = null, string sort = "Newest")
     {
-        return await _db.Proposals
+        var query = _db.Proposals
             .Where(p => p.Status == ProposalStatus.Submitted)
-            .Include(p => p.ResearchArea)
-            .OrderByDescending(p => p.CreatedAt)
-            .ToListAsync();
+            .Where(p => !researchAreaId.HasValue || p.ResearchAreaId == researchAreaId)
+            .Include(p => p.ResearchArea);
+
+        var ordered = sort == "Oldest"
+            ? query.OrderBy(p => p.CreatedAt)
+            : query.OrderByDescending(p => p.CreatedAt);
+
+        return await ordered.ToListAsync();
     }
 
     public async Task<Proposal> AcceptProposalAsync(Guid proposalId, Guid supervisorProfileId)

--- a/src/Dyadic.Web/Pages/Supervisor/Dashboard.cshtml
+++ b/src/Dyadic.Web/Pages/Supervisor/Dashboard.cshtml
@@ -34,9 +34,34 @@
         </div>
     }
 
+    <form method="get" class="row g-2 mb-4">
+        <div class="col-auto">
+            <select name="ResearchAreaFilter" class="form-select" onchange="this.form.submit()">
+                <option value="">All Research Areas</option>
+                @foreach (var area in Model.ResearchAreaOptions)
+                {
+                    <option value="@area.Value" selected="@(Model.ResearchAreaFilter.ToString() == area.Value)">@area.Text</option>
+                }
+            </select>
+        </div>
+        <div class="col-auto">
+            <select name="Sort" class="form-select" onchange="this.form.submit()">
+                <option value="Newest" selected="@(Model.Sort == "Newest")">Newest first</option>
+                <option value="Oldest" selected="@(Model.Sort == "Oldest")">Oldest first</option>
+            </select>
+        </div>
+    </form>
+
     @if (!Model.Proposals.Any())
     {
-        <p class="text-muted">No submitted proposals available for review at this time.</p>
+        @if (Model.ResearchAreaFilter.HasValue)
+        {
+            <p class="text-muted">No submitted proposals match your filter. Try widening the filter or check back later.</p>
+        }
+        else
+        {
+            <p class="text-muted">No submitted proposals available for review at this time.</p>
+        }
     }
     else
     {

--- a/src/Dyadic.Web/Pages/Supervisor/Dashboard.cshtml.cs
+++ b/src/Dyadic.Web/Pages/Supervisor/Dashboard.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Dyadic.Web.Pages.Supervisor;
 
@@ -12,15 +13,18 @@ public class DashboardModel : PageModel
 {
     private readonly IProposalService _proposalService;
     private readonly ISupervisorProfileService _supervisorProfileService;
+    private readonly IResearchAreaService _researchAreaService;
     private readonly UserManager<ApplicationUser> _userManager;
 
     public DashboardModel(
         IProposalService proposalService,
         ISupervisorProfileService supervisorProfileService,
+        IResearchAreaService researchAreaService,
         UserManager<ApplicationUser> userManager)
     {
         _proposalService = proposalService;
         _supervisorProfileService = supervisorProfileService;
+        _researchAreaService = researchAreaService;
         _userManager = userManager;
     }
 
@@ -30,6 +34,13 @@ public class DashboardModel : PageModel
     public bool AtCapacity => AcceptedCount >= MaxStudents;
     public string Department { get; set; } = string.Empty;
     public string ResearchAreas { get; set; } = string.Empty;
+    public List<SelectListItem> ResearchAreaOptions { get; set; } = new();
+
+    [BindProperty(SupportsGet = true)]
+    public Guid? ResearchAreaFilter { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string Sort { get; set; } = "Newest";
 
     public async Task OnGetAsync()
     {
@@ -41,7 +52,13 @@ public class DashboardModel : PageModel
         MaxStudents = profile.MaxStudents;
         Department = profile.Department;
         ResearchAreas = profile.ResearchAreas;
-        Proposals = await _proposalService.GetSubmittedProposalsAsync();
+
+        var areas = await _researchAreaService.GetActiveAsync();
+        ResearchAreaOptions = areas
+            .Select(a => new SelectListItem(a.Name, a.Id.ToString()))
+            .ToList();
+
+        Proposals = await _proposalService.GetSubmittedProposalsAsync(ResearchAreaFilter, Sort);
     }
 
     public async Task<IActionResult> OnPostAsync(Guid proposalId)
@@ -62,7 +79,13 @@ public class DashboardModel : PageModel
             MaxStudents = profile.MaxStudents;
             Department = profile.Department;
             ResearchAreas = profile.ResearchAreas;
-            Proposals = await _proposalService.GetSubmittedProposalsAsync();
+
+            var areas = await _researchAreaService.GetActiveAsync();
+            ResearchAreaOptions = areas
+                .Select(a => new SelectListItem(a.Name, a.Id.ToString()))
+                .ToList();
+
+            Proposals = await _proposalService.GetSubmittedProposalsAsync(ResearchAreaFilter, Sort);
             return Page();
         }
 


### PR DESCRIPTION
## Summary
  - Adds Research Area filter dropdown and Sort dropdown to the supervisor blind-review dashboard
  - Filtering and sorting are GET-based with query param binding — shareable URLs work out of the box
  - Empty state message distinguishes between no proposals at all vs no proposals matching the filter

  ## Changes
  - `Application`: `GetSubmittedProposalsAsync` signature updated with optional `researchAreaId` and `sort` params
  - `Infrastructure`: `ProposalService` — `.Where` filter clause + conditional `OrderBy`/`OrderByDescending` on `CreatedAt`; privacy unchanged (no Student identity loaded)
  - `Web`: `Dashboard.cshtml.cs` — injected `IResearchAreaService`, added `ResearchAreaFilter` and `Sort` BindProperties; `Dashboard.cshtml` — GET form with two dropdowns, `onchange` instant
  submit, conditional empty state

  ## Testing
  - [x] Research area dropdown shows all active areas + "All" option
  - [x] Selecting a research area filters the proposal cards immediately
  - [x] Selecting "All" restores the full list
  - [x] Sort "Newest first" / "Oldest first" reorders cards by submitted date
  - [x] URL contains `?ResearchAreaFilter=...&Sort=Oldest` — pasting the URL restores the same filter
  - [x] Filtering to an area with no proposals shows "No submitted proposals match your filter. Try widening the filter or check back later."
  - [x] No filter shows original "No submitted proposals available" message
  - [x] Express Interest button and capacity banner unchanged
  - [x] `dotnet build` passes with no warnings

  ## Screenshots
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 43 36" src="https://github.com/user-attachments/assets/26732d0b-53c4-46c6-8605-d03960d84518" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 44 37" src="https://github.com/user-attachments/assets/0d65c85d-604b-4ec6-890f-edcf59570e5f" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 44 55" src="https://github.com/user-attachments/assets/72ce09f5-f01d-449c-b749-3457546edbc2" />
<img width="1912" height="999" alt="Screenshot 2026-04-19 at 19 45 07" src="https://github.com/user-attachments/assets/9a9b7c30-b290-4f87-b4ed-43d37d0acf5e" />


  ## Checklist
  - [x] `SupportsGet = true` on both BindProperties
  - [x] Form uses `method="get"` — no POST, no antiforgery needed
  - [x] Privacy unchanged — `GetSubmittedProposalsAsync` has no `.Include(p => p.Student)`
  - [x] Build clean

  ## Closes
  Closes #58