### PR TITLE
test: WebApplicationFactory E2E journey tests for all three roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run InMemory Integration Tests
         run: dotnet test tests/Dyadic.IntegrationTests --no-build --verbosity normal --filter "Category=InMemory"
 
+      - name: Run E2E Journey Tests
+        run: dotnet test tests/Dyadic.IntegrationTests --no-build --verbosity normal --filter "Category=EndToEnd"
+
       - name: Run SqlServer Integration Tests
         run: dotnet test tests/Dyadic.IntegrationTests --no-build --verbosity normal --filter "Category=SqlServer"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ CLAUDE.md
 *.userosscache
 *.sln.docstates
 
+# Tests
+coverage-report/
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Author: Dwain
-.PHONY: help setup up down run test test-sql migrate reset-db clean fresh db-check
+.PHONY: help setup up down run test test-sql test-e2e migrate reset-db clean fresh db-check
 
 # Default target
 help:
@@ -10,6 +10,7 @@ help:
 	@echo " make run            RUN THE WEB APP"
 	@echo " make test           RUN UNIT + INMEMORY TESTS (NO DOCKER REQUIRED)"
 	@echo " make test-sql       RUN SQL SERVER INTEGRATION TESTS (REQUIRES: make up)"
+	@echo " make test-e2e       RUN END-TO-END JOURNEY TESTS (NO DOCKER REQUIRED)"
 	@echo " make migrate        APPLY PENDING EF CORE MIGRATIONS"
 	@echo " make reset-db       WIPE DATABASE AND RE-APPLY ALL MIGRATIONS (BE CAREFUL!)"
 	@echo " make clean          REMOVE BUILD ARTIFACTS (bin/, obj/)"
@@ -34,6 +35,9 @@ test:
 
 test-sql:
 	dotnet test --filter "Category=SqlServer"
+
+test-e2e:
+	dotnet test --filter "Category=EndToEnd"
 
 migrate:
 	dotnet ef database update -p src/Dyadic.Infrastructure -s src/Dyadic.Web

--- a/src/Dyadic.Web/Program.cs
+++ b/src/Dyadic.Web/Program.cs
@@ -63,3 +63,5 @@ app.UseAuthorization();
 app.MapRazorPages();
 
 await app.RunAsync();
+
+public partial class Program { }

--- a/tests/Dyadic.IntegrationTests/E2E/AdminJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/AdminJourneyTests.cs
@@ -1,0 +1,110 @@
+using Dyadic.Domain.Entities;
+using Dyadic.Domain.Enums;
+using Dyadic.Infrastructure;
+using Dyadic.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dyadic.IntegrationTests.E2E;
+
+[Trait("Category", "EndToEnd")]
+public class AdminJourneyTests : IAsyncLifetime
+{
+    private readonly TestWebApplicationFactory _factory;
+    private HttpClient _client = null!;
+    private Guid _proposalId;
+    private Guid _newSupervisorProfileId;
+
+    public AdminJourneyTests()
+    {
+        _factory = new TestWebApplicationFactory();
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Seed two supervisors and one student + proposal assigned to supervisor A
+        var supAUser = await _factory.SeedUserAsync("Dr. Alpha", "alpha@test.com", "Supervisor");
+        var supBUser = await _factory.SeedUserAsync("Dr. Beta", "beta@test.com", "Supervisor");
+        var studentUser = await _factory.SeedUserAsync("Charlie Student", "charlie@test.com", "Student");
+
+        var supAProfileId = Guid.NewGuid();
+        _newSupervisorProfileId = Guid.NewGuid();
+        var studentProfileId = Guid.NewGuid();
+        _proposalId = Guid.NewGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.SupervisorProfiles.Add(new SupervisorProfile
+        {
+            Id = supAProfileId,
+            UserId = supAUser.Id,
+            Department = "CS",
+            MaxStudents = 3
+        });
+        db.SupervisorProfiles.Add(new SupervisorProfile
+        {
+            Id = _newSupervisorProfileId,
+            UserId = supBUser.Id,
+            Department = "Math",
+            MaxStudents = 3
+        });
+        db.StudentProfiles.Add(new StudentProfile
+        {
+            Id = studentProfileId,
+            UserId = studentUser.Id,
+            IndexNumber = "ST201",
+            Batch = "2026"
+        });
+        db.Proposals.Add(new Proposal
+        {
+            Id = _proposalId,
+            Title = "Admin Journey Test Proposal",
+            Abstract = "This research covers advanced topics in cybersecurity and threat detection systems.",
+            TechStack = "Python, Snort",
+            StudentId = studentProfileId,
+            SupervisorId = supAProfileId,
+            Status = ProposalStatus.Accepted
+        });
+
+        await db.SaveChangesAsync();
+
+        // Login as the seeded admin (admin@dyadic.local / Admin@123456)
+        _client = await _factory.GetAuthenticatedClientAsync("admin@dyadic.local", "Admin@123456");
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Admin_CanViewDashboard_ReassignProposal_AndSeeAuditLog()
+    {
+        // Step 1 — GET /Admin/Dashboard and assert proposal is visible
+        var dashGet = await _client.GetAsync("/Admin/Dashboard");
+        dashGet.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var dashHtml = await dashGet.Content.ReadAsStringAsync();
+        dashHtml.Should().Contain("Admin Journey Test Proposal");
+
+        // Step 2 — POST Reassign
+        var token = TestWebApplicationFactory.ExtractAntiforgeryToken(dashHtml);
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["ProposalId"]                 = _proposalId.ToString(),
+            ["NewSupervisorId"]            = _newSupervisorProfileId.ToString(),
+            ["Reason"]                     = "Reassigning for workload balancing purposes",
+            ["__RequestVerificationToken"] = token
+        });
+        var reassignResponse = await _client.PostAsync("/Admin/Dashboard?handler=Reassign", form);
+
+        reassignResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+
+        // Step 3 — GET /Admin/AuditLog and assert the Reassign event is listed
+        var auditResponse = await _client.GetAsync("/Admin/AuditLog");
+        auditResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var auditHtml = await auditResponse.Content.ReadAsStringAsync();
+        auditHtml.Should().Contain("Reassign");
+    }
+}

--- a/tests/Dyadic.IntegrationTests/E2E/AdminJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/AdminJourneyTests.cs
@@ -90,7 +90,7 @@ public class AdminJourneyTests : IAsyncLifetime
 
         // Step 2 — POST Reassign
         var token = TestWebApplicationFactory.ExtractAntiforgeryToken(dashHtml);
-        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["ProposalId"]                 = _proposalId.ToString(),
             ["NewSupervisorId"]            = _newSupervisorProfileId.ToString(),

--- a/tests/Dyadic.IntegrationTests/E2E/StudentJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/StudentJourneyTests.cs
@@ -1,0 +1,108 @@
+using Dyadic.Domain.Enums;
+using Dyadic.Infrastructure;
+using Dyadic.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dyadic.IntegrationTests.E2E;
+
+[Trait("Category", "EndToEnd")]
+public class StudentJourneyTests : IAsyncLifetime
+{
+    private readonly TestWebApplicationFactory _factory;
+    private Guid _researchAreaId;
+
+    public StudentJourneyTests()
+    {
+        _factory = new TestWebApplicationFactory();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _researchAreaId = await _factory.SeedResearchAreaAsync("Artificial Intelligence");
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Student_SubmitProposal_RedirectsToMyProposal_AndStatusIsSubmitted()
+    {
+        await _factory.SeedUserAsync("Alice Student", "alice@test.com", "Student");
+        var client = await _factory.GetAuthenticatedClientAsync("alice@test.com");
+
+        // GET submit page to obtain antiforgery token
+        var getResponse = await client.GetAsync("/Student/SubmitProposal");
+        getResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var token = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await getResponse.Content.ReadAsStringAsync());
+
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Input.Title"]                = "Machine Learning in Healthcare",
+            ["Input.Abstract"]             = "This research explores the use of machine learning algorithms in healthcare diagnostics and treatment planning.",
+            ["Input.TechStack"]            = "Python, TensorFlow",
+            ["Input.ResearchAreaId"]       = _researchAreaId.ToString(),
+            ["__RequestVerificationToken"] = token
+        });
+
+        var response = await client.PostAsync("/Student/SubmitProposal?handler=Submit", form);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+        response.Headers.Location?.ToString().Should().Contain("/Student/MyProposal");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var proposal = await db.Proposals
+            .FirstOrDefaultAsync(p => p.Title == "Machine Learning in Healthcare");
+        proposal.Should().NotBeNull();
+        proposal!.Status.Should().Be(ProposalStatus.Submitted);
+    }
+
+    [Fact]
+    public async Task Student_WithdrawProposal_RevertsToDraft()
+    {
+        await _factory.SeedUserAsync("Bob Student", "bob@test.com", "Student");
+        var client = await _factory.GetAuthenticatedClientAsync("bob@test.com");
+
+        // Submit a proposal first
+        var submitGet = await client.GetAsync("/Student/SubmitProposal");
+        var submitToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await submitGet.Content.ReadAsStringAsync());
+
+        await client.PostAsync("/Student/SubmitProposal?handler=Submit",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Input.Title"]                = "Blockchain for Supply Chain",
+                ["Input.Abstract"]             = "This research investigates blockchain applications in modern supply chain management and logistics systems.",
+                ["Input.TechStack"]            = "Solidity, Ethereum",
+                ["Input.ResearchAreaId"]       = _researchAreaId.ToString(),
+                ["__RequestVerificationToken"] = submitToken
+            }));
+
+        // GET MyProposal to obtain withdraw antiforgery token
+        var myProposalGet = await client.GetAsync("/Student/MyProposal");
+        myProposalGet.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var withdrawToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await myProposalGet.Content.ReadAsStringAsync());
+
+        var response = await client.PostAsync("/Student/MyProposal?handler=Withdraw",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["__RequestVerificationToken"] = withdrawToken
+            }));
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var proposal = await db.Proposals
+            .FirstOrDefaultAsync(p => p.Title == "Blockchain for Supply Chain");
+        proposal.Should().NotBeNull();
+        proposal!.Status.Should().Be(ProposalStatus.Draft);
+    }
+}

--- a/tests/Dyadic.IntegrationTests/E2E/StudentJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/StudentJourneyTests.cs
@@ -1,3 +1,5 @@
+using Dyadic.Application.Services;
+using Dyadic.Domain.Entities;
 using Dyadic.Domain.Enums;
 using Dyadic.Infrastructure;
 using Dyadic.IntegrationTests.Fixtures;
@@ -35,13 +37,12 @@ public class StudentJourneyTests : IAsyncLifetime
         await _factory.SeedUserAsync("Alice Student", "alice@test.com", "Student");
         var client = await _factory.GetAuthenticatedClientAsync("alice@test.com");
 
-        // GET submit page to obtain antiforgery token
         var getResponse = await client.GetAsync("/Student/SubmitProposal");
         getResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var token = TestWebApplicationFactory.ExtractAntiforgeryToken(
             await getResponse.Content.ReadAsStringAsync());
 
-        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["Input.Title"]                = "Machine Learning in Healthcare",
             ["Input.Abstract"]             = "This research explores the use of machine learning algorithms in healthcare diagnostics and treatment planning.",
@@ -69,32 +70,30 @@ public class StudentJourneyTests : IAsyncLifetime
         await _factory.SeedUserAsync("Bob Student", "bob@test.com", "Student");
         var client = await _factory.GetAuthenticatedClientAsync("bob@test.com");
 
-        // Submit a proposal first
         var submitGet = await client.GetAsync("/Student/SubmitProposal");
         var submitToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
             await submitGet.Content.ReadAsStringAsync());
 
-        await client.PostAsync("/Student/SubmitProposal?handler=Submit",
-            new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["Input.Title"]                = "Blockchain for Supply Chain",
-                ["Input.Abstract"]             = "This research investigates blockchain applications in modern supply chain management and logistics systems.",
-                ["Input.TechStack"]            = "Solidity, Ethereum",
-                ["Input.ResearchAreaId"]       = _researchAreaId.ToString(),
-                ["__RequestVerificationToken"] = submitToken
-            }));
+        using var submitForm = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Input.Title"]                = "Blockchain for Supply Chain",
+            ["Input.Abstract"]             = "This research investigates blockchain applications in modern supply chain management and logistics systems.",
+            ["Input.TechStack"]            = "Solidity, Ethereum",
+            ["Input.ResearchAreaId"]       = _researchAreaId.ToString(),
+            ["__RequestVerificationToken"] = submitToken
+        });
+        await client.PostAsync("/Student/SubmitProposal?handler=Submit", submitForm);
 
-        // GET MyProposal to obtain withdraw antiforgery token
         var myProposalGet = await client.GetAsync("/Student/MyProposal");
         myProposalGet.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var withdrawToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
             await myProposalGet.Content.ReadAsStringAsync());
 
-        var response = await client.PostAsync("/Student/MyProposal?handler=Withdraw",
-            new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["__RequestVerificationToken"] = withdrawToken
-            }));
+        using var withdrawForm = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["__RequestVerificationToken"] = withdrawToken
+        });
+        var response = await client.PostAsync("/Student/MyProposal?handler=Withdraw", withdrawForm);
 
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
 
@@ -104,5 +103,81 @@ public class StudentJourneyTests : IAsyncLifetime
             .FirstOrDefaultAsync(p => p.Title == "Blockchain for Supply Chain");
         proposal.Should().NotBeNull();
         proposal!.Status.Should().Be(ProposalStatus.Draft);
+    }
+
+    [Fact]
+    public async Task FullJourney_Register_SubmitProposal_ConfirmMatch_SeesSupervisor()
+    {
+        // 1. Register + login Student
+        await _factory.SeedUserAsync("Carol Student", "carol@test.com", "Student");
+        var client = await _factory.GetAuthenticatedClientAsync("carol@test.com");
+
+        // 2. Student submits a proposal via HTTP
+        var submitGet = await client.GetAsync("/Student/SubmitProposal");
+        var submitToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await submitGet.Content.ReadAsStringAsync());
+
+        using var submitForm = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Input.Title"]                = "Full Journey Research Proposal",
+            ["Input.Abstract"]             = "This research explores the end-to-end matching workflow from student submission through supervisor confirmation and identity reveal.",
+            ["Input.TechStack"]            = "C#, ASP.NET Core",
+            ["Input.ResearchAreaId"]       = _researchAreaId.ToString(),
+            ["__RequestVerificationToken"] = submitToken
+        });
+        var submitResponse = await client.PostAsync("/Student/SubmitProposal?handler=Submit", submitForm);
+        submitResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+
+        // 3. Seed a supervisor and advance the proposal to Accepted via the service layer
+        //    (supervisor HTTP journey is covered separately in SupervisorJourneyTests)
+        var supervisor = await _factory.SeedUserAsync("Dr. Reveal", "reveal@test.com", "Supervisor");
+        Guid proposalId;
+
+        using (var arrangeScope = _factory.Services.CreateScope())
+        {
+            var db = arrangeScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var proposalSvc = arrangeScope.ServiceProvider.GetRequiredService<IProposalService>();
+
+            var supervisorProfile = new SupervisorProfile
+            {
+                Id = Guid.NewGuid(),
+                UserId = supervisor.Id,
+                Department = "CS",
+                MaxStudents = 3
+            };
+            db.SupervisorProfiles.Add(supervisorProfile);
+            await db.SaveChangesAsync();
+
+            var proposal = await db.Proposals
+                .FirstAsync(p => p.Title == "Full Journey Research Proposal");
+            proposalId = proposal.Id;
+
+            await proposalSvc.AcceptProposalAsync(proposal.Id, supervisorProfile.Id);
+        }
+
+        // 4. Student confirms the match
+        var confirmGet = await client.GetAsync("/Student/MyProposal");
+        confirmGet.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var confirmToken = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await confirmGet.Content.ReadAsStringAsync());
+
+        using var confirmForm = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["proposalId"]                 = proposalId.ToString(),
+            ["__RequestVerificationToken"] = confirmToken
+        });
+        var confirmResponse = await client.PostAsync("/Student/MyProposal?handler=Confirm", confirmForm);
+        confirmResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+
+        using var assertScope = _factory.Services.CreateScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var finalized = await assertDb.Proposals.FindAsync(proposalId);
+        finalized!.Status.Should().Be(ProposalStatus.Finalized);
+
+        // 5. Reveal — GET MyProposal, assert supervisor name appears in the response body
+        var revealResponse = await client.GetAsync("/Student/MyProposal");
+        revealResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var revealHtml = await revealResponse.Content.ReadAsStringAsync();
+        revealHtml.Should().Contain("Dr. Reveal");
     }
 }

--- a/tests/Dyadic.IntegrationTests/E2E/SupervisorJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/SupervisorJourneyTests.cs
@@ -1,0 +1,91 @@
+using Dyadic.Domain.Entities;
+using Dyadic.Domain.Enums;
+using Dyadic.Infrastructure;
+using Dyadic.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dyadic.IntegrationTests.E2E;
+
+[Trait("Category", "EndToEnd")]
+public class SupervisorJourneyTests : IAsyncLifetime
+{
+    private readonly TestWebApplicationFactory _factory;
+    private HttpClient _client = null!;
+    private Guid _proposalId;
+
+    public SupervisorJourneyTests()
+    {
+        _factory = new TestWebApplicationFactory();
+    }
+
+    public async Task InitializeAsync()
+    {
+        var supervisorUser = await _factory.SeedUserAsync("Dr. Smith", "smith@test.com", "Supervisor");
+
+        // Seed a student profile + submitted proposal directly via DbContext.
+        // FK constraints are not enforced by InMemory so we use a stub student user ID.
+        var studentProfileId = Guid.NewGuid();
+        _proposalId = Guid.NewGuid();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.StudentProfiles.Add(new StudentProfile
+        {
+            Id = studentProfileId,
+            UserId = Guid.NewGuid(),
+            IndexNumber = "ST001",
+            Batch = "2026"
+        });
+
+        db.Proposals.Add(new Proposal
+        {
+            Id = _proposalId,
+            Title = "Supervisor Journey Test Proposal",
+            Abstract = "This research explores advanced topics in distributed systems and cloud computing architectures.",
+            TechStack = "Go, Kubernetes",
+            StudentId = studentProfileId,
+            Status = ProposalStatus.Submitted
+        });
+
+        await db.SaveChangesAsync();
+
+        _client = await _factory.GetAuthenticatedClientAsync("smith@test.com");
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Supervisor_AcceptsProposal_RedirectsToAcceptedProposals_AndStatusIsAccepted()
+    {
+        // GET dashboard to obtain antiforgery token
+        var getResponse = await _client.GetAsync("/Supervisor/Dashboard");
+        getResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var token = TestWebApplicationFactory.ExtractAntiforgeryToken(
+            await getResponse.Content.ReadAsStringAsync());
+
+        // POST to accept the proposal (default OnPostAsync handler)
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["proposalId"]                 = _proposalId.ToString(),
+            ["__RequestVerificationToken"] = token
+        });
+        var response = await _client.PostAsync("/Supervisor/Dashboard", form);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+        response.Headers.Location?.ToString().Should().Contain("/Supervisor/AcceptedProposals");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var proposal = await db.Proposals.FindAsync(_proposalId);
+        proposal.Should().NotBeNull();
+        proposal!.Status.Should().Be(ProposalStatus.Accepted);
+        proposal.SupervisorId.Should().NotBeNull();
+    }
+}

--- a/tests/Dyadic.IntegrationTests/E2E/SupervisorJourneyTests.cs
+++ b/tests/Dyadic.IntegrationTests/E2E/SupervisorJourneyTests.cs
@@ -22,7 +22,7 @@ public class SupervisorJourneyTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var supervisorUser = await _factory.SeedUserAsync("Dr. Smith", "smith@test.com", "Supervisor");
+        _ = await _factory.SeedUserAsync("Dr. Smith", "smith@test.com", "Supervisor");
 
         // Seed a student profile + submitted proposal directly via DbContext.
         // FK constraints are not enforced by InMemory so we use a stub student user ID.
@@ -71,7 +71,7 @@ public class SupervisorJourneyTests : IAsyncLifetime
             await getResponse.Content.ReadAsStringAsync());
 
         // POST to accept the proposal (default OnPostAsync handler)
-        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["proposalId"]                 = _proposalId.ToString(),
             ["__RequestVerificationToken"] = token

--- a/tests/Dyadic.IntegrationTests/Fixtures/TestWebApplicationFactory.cs
+++ b/tests/Dyadic.IntegrationTests/Fixtures/TestWebApplicationFactory.cs
@@ -1,0 +1,109 @@
+using Dyadic.Application.Services;
+using Dyadic.Domain.Entities;
+using Dyadic.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.RegularExpressions;
+
+namespace Dyadic.IntegrationTests.Fixtures;
+
+/// <summary>
+/// WebApplicationFactory that swaps SQL Server for InMemory and seeds Identity roles + admin on startup.
+/// Each factory instance gets its own isolated InMemory database.
+/// </summary>
+public class TestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _dbName = $"E2E_{Guid.NewGuid():N}";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor != null)
+                services.Remove(descriptor);
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase(_dbName));
+        });
+    }
+
+    /// <summary>Creates a user via UserManager and assigns the given role.</summary>
+    public async Task<ApplicationUser> SeedUserAsync(
+        string fullName, string email, string role, string password = "Test@123456")
+    {
+        using var scope = Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            FullName = fullName,
+            UserName = email,
+            Email = email,
+            EmailConfirmed = true
+        };
+
+        var result = await userManager.CreateAsync(user, password);
+        if (!result.Succeeded)
+            throw new InvalidOperationException(
+                $"Seed user failed: {string.Join(", ", result.Errors.Select(e => e.Description))}");
+
+        await userManager.AddToRoleAsync(user, role);
+        return user;
+    }
+
+    /// <summary>Creates an active research area via IResearchAreaService and returns its ID.</summary>
+    public async Task<Guid> SeedResearchAreaAsync(string name = "Computer Science")
+    {
+        using var scope = Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IResearchAreaService>();
+        var area = await service.CreateAsync(name);
+        return area.Id;
+    }
+
+    /// <summary>
+    /// Creates an HttpClient authenticated as the given user.
+    /// Fetches the login page to obtain the antiforgery token, then POSTs credentials.
+    /// Returns a client with the auth cookie already set.
+    /// Uses HTTPS base address to avoid the HTTP→HTTPS redirect from UseHttpsRedirection.
+    /// </summary>
+    public async Task<HttpClient> GetAuthenticatedClientAsync(
+        string email, string password = "Test@123456")
+    {
+        var client = CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var getResponse = await client.GetAsync("/Account/Login");
+        var html = await getResponse.Content.ReadAsStringAsync();
+        var token = ExtractAntiforgeryToken(html);
+
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Input.Email"]                = email,
+            ["Input.Password"]             = password,
+            ["Input.RememberMe"]           = "false",
+            ["__RequestVerificationToken"] = token
+        });
+
+        await client.PostAsync("/Account/Login", form);
+        return client;
+    }
+
+    /// <summary>Extracts the antiforgery token from a Razor Pages HTML response.</summary>
+    public static string ExtractAntiforgeryToken(string html)
+    {
+        var match = Regex.Match(html,
+            @"<input[^>]+name=""__RequestVerificationToken""[^>]+value=""([^""]+)""");
+        if (!match.Success)
+            match = Regex.Match(html,
+                @"<input[^>]+value=""([^""]+)""[^>]+name=""__RequestVerificationToken""");
+        return match.Success ? match.Groups[1].Value : string.Empty;
+    }
+}

--- a/tests/Dyadic.IntegrationTests/Fixtures/TestWebApplicationFactory.cs
+++ b/tests/Dyadic.IntegrationTests/Fixtures/TestWebApplicationFactory.cs
@@ -84,7 +84,7 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
         var html = await getResponse.Content.ReadAsStringAsync();
         var token = ExtractAntiforgeryToken(html);
 
-        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["Input.Email"]                = email,
             ["Input.Password"]             = password,


### PR DESCRIPTION
## Summary
  - Expose `public partial class Program {}` so `WebApplicationFactory<Program>` can reference the entry point
  - Add `TestWebApplicationFactory` fixture: swaps SQL Server for InMemory, seeds users via `UserManager`, handles antiforgery token extraction for authenticated HTTP clients
  - Add 4 E2E journey tests covering Student (submit + withdraw), Supervisor (accept proposal), and Admin (dashboard → reassign → audit log)
  - Add `make test-e2e` target and CI pipeline step

  ## Test plan
  - [x] `dotnet build` succeeds with 0 warnings
  - [x] `make test-e2e` → 4/4 passed locally
  - [x] `make test` (unit + InMemory) still passes — no regressions
  - [x] CI pipeline passes all three test stages (Unit, InMemory, E2E)

  ## Notes
  - E2E tests use InMemory DB — no Docker required
  - All tests tagged `[Trait("Category", "EndToEnd")]` so they can be filtered independently
  - Auth flow: `UserManager.CreateAsync` for seeding + real `POST /Account/Login` with antiforgery token — tests the actual Identity cookie pipeline
  - InMemory does not enforce FK constraints, allowing lightweight test data setup without full user graphs

  ## Related
  Closes #74