### PR TITLE
UI polish — active navbar, cancel buttons, modals, alerts, landing page

### DIFF
--- a/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/Dashboard.cshtml
@@ -9,11 +9,17 @@
 
     @if (TempData["Success"] != null)
     {
-        <div class="alert alert-success">@TempData["Success"]</div>
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @TempData["Success"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
     @if (TempData["Error"] != null)
     {
-        <div class="alert alert-danger">@TempData["Error"]</div>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @TempData["Error"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
 
     <div class="row g-3 mb-4">

--- a/src/Dyadic.Web/Pages/Admin/ResearchAreas.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/ResearchAreas.cshtml
@@ -12,11 +12,17 @@
 
     @if (TempData["Success"] != null)
     {
-        <div class="alert alert-success">@TempData["Success"]</div>
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @TempData["Success"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
     @if (TempData["Error"] != null)
     {
-        <div class="alert alert-danger">@TempData["Error"]</div>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @TempData["Error"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
 
     <div class="table-responsive">
@@ -57,13 +63,13 @@
                             </button>
                             @if (area.IsActive)
                             {
-                                <form method="post" asp-page-handler="Deactivate" class="d-inline">
-                                    <input type="hidden" name="id" value="@area.Id" />
-                                    <button type="submit" class="btn btn-sm btn-outline-danger"
-                                            onclick="return confirm('Deactivate @area.Name? It will be hidden from the student dropdown but historical proposals are preserved.')">
-                                        Deactivate
-                                    </button>
-                                </form>
+                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#deactivateAreaModal"
+                                        data-area-id="@area.Id"
+                                        data-area-name="@area.Name">
+                                    Deactivate
+                                </button>
                             }
                             else {
                                 <form method ="post" asp-page-handler="Reactivate" class="d-inline">
@@ -105,6 +111,28 @@
     </div>
 </div>
 
+<!-- Deactivate Modal -->
+<div class="modal fade" id="deactivateAreaModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Deactivate Research Area</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Deactivate <strong id="deactivateAreaName"></strong>? It will be hidden from the student dropdown but historical proposals are preserved.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="post" asp-page-handler="Deactivate">
+                    <input type="hidden" name="id" id="deactivateAreaId" />
+                    <button type="submit" class="btn btn-danger">Deactivate</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Edit Modal -->
 <div class="modal fade" id="editModal" tabindex="-1">
     <div class="modal-dialog">
@@ -135,6 +163,10 @@
         document.getElementById('editModal').addEventListener('show.bs.modal', function (e) {
             document.getElementById('editAreaId').value = e.relatedTarget.dataset.areaId;
             document.getElementById('editAreaName').value = e.relatedTarget.dataset.areaName;
+        });
+        document.getElementById('deactivateAreaModal').addEventListener('show.bs.modal', function (e) {
+            document.getElementById('deactivateAreaId').value = e.relatedTarget.dataset.areaId;
+            document.getElementById('deactivateAreaName').textContent = e.relatedTarget.dataset.areaName;
         });
     </script>
 }

--- a/src/Dyadic.Web/Pages/Admin/Users.cshtml
+++ b/src/Dyadic.Web/Pages/Admin/Users.cshtml
@@ -10,7 +10,10 @@
 
     @if (TempData["Error"] != null)
     {
-        <div class="alert alert-danger">@TempData["Error"]</div>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @TempData["Error"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
 
     <form method="get" class="row g-2 mb-4">
@@ -88,14 +91,14 @@
 
                                     @if (u.IsActive)
                                     {
-                                        <form method="post" class="d-inline">
-                                            <input type="hidden" name="userId" value="@u.Id" />
-                                            <button type="submit" asp-page-handler="Deactivate"
-                                                    class="btn btn-sm btn-outline-danger"
-                                                    onclick="return confirm('Deactivate @u.FullName? They won\'t be able to log in. Their proposals and audit history remain intact.')">
-                                                Deactivate
-                                            </button>
-                                        </form>
+                                        <button type="button"
+                                                class="btn btn-sm btn-outline-danger"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#deactivateUserModal"
+                                                data-user-id="@u.Id"
+                                                data-user-name="@u.FullName">
+                                            Deactivate
+                                        </button>
                                     }
                                     else
                                     {
@@ -124,6 +127,37 @@
         <a asp-page="/Admin/Dashboard" class="btn btn-outline-secondary">Back to Dashboard</a>
     </div>
 </div>
+
+<!-- Deactivate User Modal -->
+<div class="modal fade" id="deactivateUserModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Deactivate User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Deactivate <strong id="deactivateUserName"></strong>? They won't be able to log in. Their proposals and audit history remain intact.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="post">
+                    <input type="hidden" name="userId" id="deactivateUserId" />
+                    <button type="submit" asp-page-handler="Deactivate" class="btn btn-danger">Deactivate</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.getElementById('deactivateUserModal').addEventListener('show.bs.modal', function (e) {
+            document.getElementById('deactivateUserId').value = e.relatedTarget.dataset.userId;
+            document.getElementById('deactivateUserName').textContent = e.relatedTarget.dataset.userName;
+        });
+    </script>
+}
 
 @foreach (var u in Model.Users.Where(u => u.Id != Model.CurrentAdminId))
 {

--- a/src/Dyadic.Web/Pages/Index.cshtml
+++ b/src/Dyadic.Web/Pages/Index.cshtml
@@ -7,10 +7,16 @@
 <div class="text-center py-5">
     <h1 class="display-4 fw-bold">Dyadic</h1>
     <p class="lead text-muted mb-4">
-        A blind proposal matching system - connecting student research proposals to academic supervisors fairly and transparently.
+        A blind proposal matching system — connecting student research proposals to academic supervisors fairly and transparently.
     </p>
-    <div class="d-flex flex-column flex-sm-row justify-content-center gap-3">
+    <ul class="list-unstyled text-start d-inline-block mb-4">
+        <li class="mb-2">&#x1F512; <strong>Blind matching</strong> — Proposals reviewed without bias; supervisors see the work, not the student</li>
+        <li class="mb-2">&#x1F4CB; <strong>Transparent allocation</strong> — Every state change and admin override logged, visible to the Module Leader</li>
+        <li class="mb-2">&#x2696; <strong>Fair capacity</strong> — MaxStudents per supervisor enforced at the service layer, no silent overloads</li>
+    </ul>
+    <div class="d-flex flex-column flex-sm-row justify-content-center gap-3 mb-3">
         <a asp-page="/Account/Register" class="btn btn-success btn-lg">Get Started</a>
         <a asp-page="/Account/Login" class="btn btn-outline-success btn-lg">Login</a>
     </div>
+    <p class="text-muted small">PUSL2020 Group AO &mdash; NSBM Green University</p>
 </div>

--- a/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Dyadic.Web/Pages/Shared/_Layout.cshtml
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="~/Dyadic.Web.styles.css" asp-append-version="true" />
 </head>
 <body>
+@{ var currentPage = ViewContext.RouteData.Values["Page"]?.ToString() ?? ""; }
     <header>
         <nav class="navbar navbar-expand-lg navbar-dark bg-success border-bottom box-shadow mb-3">
             <div class="container">
@@ -24,45 +25,45 @@
                 <div class="navbar-collapse collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto">
                         <li class="nav-item">
-                            <a class="nav-link text-white" asp-page="/Index">Home</a>
+                            <a class="nav-link text-white @(currentPage == "/Index" ? "active fw-bold" : "")" asp-page="/Index">Home</a>
                         </li>
                         @if (SignInManager.IsSignedIn(User) && User.IsInRole("Student"))
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Student/MyProposal">My Proposal</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Student/MyProposal") ? "active fw-bold" : "")" asp-page="/Student/MyProposal">My Proposal</a>
                             </li>
                         }
                         else if (SignInManager.IsSignedIn(User) && User.IsInRole("Supervisor"))
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Supervisor/Dashboard">Review Proposals</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Supervisor/Dashboard") ? "active fw-bold" : "")" asp-page="/Supervisor/Dashboard">Review Proposals</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Supervisor/Profile">My Profile</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Supervisor/Profile") ? "active fw-bold" : "")" asp-page="/Supervisor/Profile">My Profile</a>
                             </li>
                         }
                         else if (SignInManager.IsSignedIn(User) && User.IsInRole("Admin"))
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Admin/Dashboard">Admin Dashboard</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Admin/Dashboard") ? "active fw-bold" : "")" asp-page="/Admin/Dashboard">Admin Dashboard</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Admin/Supervisors">Supervisors</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Admin/Supervisors") ? "active fw-bold" : "")" asp-page="/Admin/Supervisors">Supervisors</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Admin/AuditLog">Audit Log</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Admin/AuditLog") ? "active fw-bold" : "")" asp-page="/Admin/AuditLog">Audit Log</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Admin/ResearchAreas">Research Areas</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Admin/ResearchAreas") ? "active fw-bold" : "")" asp-page="/Admin/ResearchAreas">Research Areas</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Admin/Users">Users</a>
+                                <a class="nav-link text-white @(currentPage.StartsWith("/Admin/Users") ? "active fw-bold" : "")" asp-page="/Admin/Users">Users</a>
                             </li>
                         }
                         else if (SignInManager.IsSignedIn(User))
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Dashboard">Dashboard</a>
+                                <a class="nav-link text-white @(currentPage == "/Dashboard" ? "active fw-bold" : "")" asp-page="/Dashboard">Dashboard</a>
                             </li>
                         }
                     </ul>
@@ -81,10 +82,10 @@
                         else
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Account/Login">Login</a>
+                                <a class="nav-link text-white @(currentPage == "/Account/Login" ? "active fw-bold" : "")" asp-page="/Account/Login">Login</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-white" asp-page="/Account/Register">Register</a>
+                                <a class="nav-link text-white @(currentPage == "/Account/Register" ? "active fw-bold" : "")" asp-page="/Account/Register">Register</a>
                             </li>
                         }
                     </ul>
@@ -110,5 +111,12 @@
     <script src="~/js/site.js" asp-append-version="true"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
+    <script>
+        setTimeout(function () {
+            document.querySelectorAll('.alert-dismissible').forEach(function (el) {
+                bootstrap.Alert.getOrCreateInstance(el).close();
+            });
+        }, 5000);
+    </script>
 </body>
 </html>

--- a/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/MyProposal.cshtml
@@ -62,33 +62,21 @@
                     <strong>&#8987; Awaiting supervisor interest</strong><br />
                     Your proposal has been submitted to the supervisor pool. A supervisor will review it and reach out if they're interested — you'll see a confirmation request here when that happens.
                 </div>
-                <form method="post">
-                    <button type="submit" asp-page-handler="Withdraw"
-                            class="btn btn-outline-danger"
-                            onclick="return confirm('Are you sure you want to withdraw your proposal? It will return to Draft status.')">
-                        Withdraw Proposal
-                    </button>
-                </form>
+                <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#withdrawModal">
+                    Withdraw Proposal
+                </button>
             }
             else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Accepted)
             {
                 <div class="alert alert-info mt-3">
                     A supervisor has expressed interest in your proposal.
                 </div>
-                <form method="post" class="d-inline me-2">
-                    <input type="hidden" name="proposalId" value="@Model.Proposal.Id" />
-                    <button type="submit" asp-page-handler="Confirm" class="btn btn-success"
-                            onclick="return confirm('Confirm this match? This will finalize your proposal.')">
-                        Confirm Match
-                    </button>
-                </form>
-                <form method="post" class="d-inline">
-                    <input type="hidden" name="proposalId" value="@Model.Proposal.Id" />
-                    <button type="submit" asp-page-handler="Reject" class="btn btn-outline-danger"
-                            onclick="return confirm('Decline this match? Your proposal will return to the pool.')">
-                        Decline Match
-                    </button>
-                </form>
+                <button type="button" class="btn btn-success me-2" data-bs-toggle="modal" data-bs-target="#confirmMatchModal">
+                    Confirm Match
+                </button>
+                <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#declineMatchModal">
+                    Decline Match
+                </button>
             }
             else if (Model.Proposal.Status == Dyadic.Domain.Enums.ProposalStatus.Finalized)
             {
@@ -115,5 +103,70 @@
                 <p class="text-muted fst-italic">This proposal is locked and cannot be edited.</p>
             }
         }
+    </div>
+</div>
+
+<!-- Withdraw Modal -->
+<div class="modal fade" id="withdrawModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Withdraw Proposal</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to withdraw your proposal? It will return to Draft status.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="post">
+                    <button type="submit" asp-page-handler="Withdraw" class="btn btn-danger">Withdraw</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Confirm Match Modal -->
+<div class="modal fade" id="confirmMatchModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Confirm Match</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Confirm this match? This will finalize your proposal and assign you to this supervisor.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="post">
+                    <input type="hidden" name="proposalId" value="@Model.Proposal?.Id" />
+                    <button type="submit" asp-page-handler="Confirm" class="btn btn-success">Confirm</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Decline Match Modal -->
+<div class="modal fade" id="declineMatchModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Decline Match</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Decline this match? Your proposal will return to the supervisor pool.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="post">
+                    <input type="hidden" name="proposalId" value="@Model.Proposal?.Id" />
+                    <button type="submit" asp-page-handler="Reject" class="btn btn-danger">Decline</button>
+                </form>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml
+++ b/src/Dyadic.Web/Pages/Student/SubmitProposal.cshtml
@@ -66,6 +66,7 @@
                 <div class="d-flex gap-3">
                     <button type="submit" asp-page-handler="Draft" class="btn btn-outline-secondary btn-lg">Save as Draft</button>
                     <button type="submit" asp-page-handler="Submit" class="btn btn-success btn-lg">Submit Proposal</button>
+                    <a asp-page="/Student/MyProposal" class="btn btn-outline-secondary btn-lg">Cancel</a>
                 </div>
             </form>
         }

--- a/src/Dyadic.Web/Pages/Supervisor/Profile.cshtml
+++ b/src/Dyadic.Web/Pages/Supervisor/Profile.cshtml
@@ -9,7 +9,10 @@
 
     @if (TempData["Success"] != null)
     {
-        <div class="alert alert-success">@TempData["Success"]</div>
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @TempData["Success"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
     }
 
     <form method="post">
@@ -34,7 +37,10 @@
             <span asp-validation-for="MaxStudents" class="text-danger"></span>
         </div>
 
-        <button type="submit" class="btn btn-success">Save Profile</button>
+        <div class="d-flex gap-3">
+            <button type="submit" class="btn btn-success">Save Profile</button>
+            <a asp-page="/Supervisor/Dashboard" class="btn btn-outline-secondary">Cancel</a>
+        </div>
     </form>
 </div>
 


### PR DESCRIPTION
## Summary
  UI polish pass covering five scoped improvements: active navbar state, cancel buttons, Bootstrap modal replacements for native confirm() dialogs, dismissible TempData alerts, and landing
  page value props.

  ## Changes
  - Active navbar link highlight across all role branches using `currentPage` from route data
  - Cancel buttons added to SubmitProposal (→ MyProposal) and Supervisor Profile (→ Dashboard)
  - Replaced all native `confirm()` dialogs with Bootstrap modals: Withdraw, Confirm Match, Decline Match on MyProposal; Deactivate on ResearchAreas and Users
  - TempData alerts made dismissible — manual close button + 5s auto-dismiss script in `_Layout.cshtml`
  - Landing page updated with three value-prop bullets and PUSL2020 Group AO attribution

  ## Testing
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated (if this PR touches DB or HTTP)
  - [x] Manually verified the feature works end-to-end
  - [x] `make test` passes locally
  - [x] `dotnet build` succeeds with no new warnings

  ## Screenshots
<img width="1912" height="999" alt="Screenshot 2026-04-20 at 00 52 19" src="https://github.com/user-attachments/assets/63ff03fa-488d-4f93-b80c-4c4a2d2a0a51" />
<img width="1912" height="999" alt="Screenshot 2026-04-20 at 00 52 46" src="https://github.com/user-attachments/assets/90b3ddcd-3e2f-4fc8-b50e-326f8568c1f2" />
<img width="1912" height="999" alt="Screenshot 2026-04-20 at 00 54 01" src="https://github.com/user-attachments/assets/ff4f5b28-3dd5-445b-8fdc-31e6b594e326" />
<img width="1912" height="999" alt="Screenshot 2026-04-20 at 00 54 43" src="https://github.com/user-attachments/assets/ba2d34e3-b107-450f-a66c-96c4b7ee862d" />
<img width="1912" height="999" alt="Screenshot 2026-04-20 at 00 57 28" src="https://github.com/user-attachments/assets/0a855c87-4492-4f24-9523-2df4c6f172e1" />


  
  ## Checklist
  - [x] Branch named `feat/thamindu-ui-polish` per CONTRIBUTING.md
  - [x] Commits follow Conventional Commits (`feat(web):`)
  - [x] No secrets, passwords, or `.env` contents committed
  - [ ] Migration added if DbContext changed (via `dotnet ef migrations add`)
  - [ ] Related docs updated (CONTRIBUTING.md, README, inline comments)

  ## Closes
  Closes #75